### PR TITLE
Type safety in statement parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,9 @@
+lazy val tokenizer = project.in(file("tokenizer"))
+
 lazy val anorm = project
   .in(file("."))
   .enablePlugins(Playdoc, Omnidoc)
+  .dependsOn(tokenizer)
 
 lazy val docs = project
   .in(file("docs"))
@@ -11,53 +14,23 @@ name := "anorm"
 
 libraryDependencies ++= Seq(
   "com.jsuereth" %% "scala-arm" % "1.4",
-  "joda-time" % "joda-time" % "2.6",
+  "joda-time" % "joda-time" % "2.6", // TODO: scope as 'provided' ?
   "org.joda" % "joda-convert" % "1.7",
 
   "com.h2database" % "h2" % "1.4.182" % Test,
-  "org.eu.acolyte" %% "jdbc-scala" % "1.0.30" % Test,
+  "org.eu.acolyte" %% "jdbc-scala" % "1.0.32" % Test,
   "com.chuusai" % "shapeless" % "2.0.0" % Test cross CrossVersion.binaryMapped {
     case "2.10" => "2.10.4"
     case x => x
   }
-)
+) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+  case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+    Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1")
+  case _ => Nil
+})
 
 libraryDependencies ++= Seq(
   "specs2-core",
   "specs2-junit",
   "specs2-mock"
 ).map("org.specs2" %% _ % "2.4.9" % Test)
-
-scalariformSettings
-
-// Release settings
-
-releaseSettings
-ReleaseKeys.crossBuild := true
-ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value
-ReleaseKeys.tagName := (version in ThisBuild).value
-
-// Publish settings
-publishTo := {
-  if (isSnapshot.value) Some(Opts.resolver.sonatypeSnapshots)
-  else Some(Opts.resolver.sonatypeStaging)
-}
-homepage := Some(url("https://github.com/playframework/anorm"))
-licenses := Seq("Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
-pomExtra := {
-  <scm>
-    <url>https://github.com/playframework/anorm</url>
-    <connection>scm:git:git@github.com:playframework/anorm.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>playframework</id>
-      <name>Play Framework Team</name>
-      <url>https://github.com/playframework</url>
-    </developer>
-  </developers>
-}
-pomIncludeRepository := { _ => false }
-
-OmnidocKeys.githubRepo := "playframework/anorm"
-OmnidocKeys.tagPrefix := ""

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,6 +1,10 @@
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
+import com.typesafe.sbt.SbtScalariform._
+import sbtrelease.ReleasePlugin._
+import com.typesafe.sbt.pgp.PgpKeys
+import interplay.Omnidoc.Import._
 
 object Common extends AutoPlugin {
   override def trigger = allRequirements
@@ -10,15 +14,7 @@ object Common extends AutoPlugin {
     organization := "com.typesafe.play",
 
     scalaVersion := sys.props.get("scala.version").getOrElse("2.10.4"),
-    crossScalaVersions := Seq("2.10.4", "2.11.1"),
-    libraryDependencies := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-          libraryDependencies.value :+ ("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1")
-        case _ =>
-          libraryDependencies.value
-      }
-    },
+    crossScalaVersions := Seq("2.10.4", "2.11.3"),
 
     scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8"),
     (javacOptions in compile) := Seq("-source", "1.7", "-target", "1.7"),
@@ -28,6 +24,38 @@ object Common extends AutoPlugin {
 
     resolvers ++= DefaultOptions.resolvers(snapshot = true),
     resolvers += Resolver.typesafeRepo("releases"),
-    resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases" // specs2 depends on scalaz-stream
-  )
+    resolvers += "Scalaz Bintray Repo" at {
+      "http://dl.bintray.com/scalaz/releases" // specs2 depends on scalaz-stream
+    },
+
+    // Publish settings
+    publishTo := {
+      if (isSnapshot.value) Some(Opts.resolver.sonatypeSnapshots)
+      else Some(Opts.resolver.sonatypeStaging)
+    },
+    homepage := Some(url("https://github.com/playframework/anorm")),
+    licenses := Seq("Apache 2" -> url(
+      "http://www.apache.org/licenses/LICENSE-2.0")),
+    pomExtra := {
+  <scm>
+    <url>https://github.com/playframework/anorm</url>
+    <connection>scm:git:git@github.com:playframework/anorm.git</connection>
+  </scm>
+  <developers>
+    <developer>
+      <id>playframework</id>
+      <name>Play Framework Team</name>
+      <url>https://github.com/playframework</url>
+    </developer>
+  </developers>
+    },
+    pomIncludeRepository := { _ => false },
+
+    OmnidocKeys.githubRepo := "playframework/anorm",
+    OmnidocKeys.tagPrefix := ""
+  ) ++ scalariformSettings ++ releaseSettings ++ Seq(
+    ReleaseKeys.crossBuild := true,
+    ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value,
+    ReleaseKeys.tagName := (version in ThisBuild).value)
+
 }

--- a/src/main/scala/anorm/Anorm.scala
+++ b/src/main/scala/anorm/Anorm.scala
@@ -309,36 +309,11 @@ object Sql { // TODO: Rename to SQL
     case _ => ps
   }
 
-  /**
-   * Rewrites next format placeholder (%s) in statement, with fragment using
-   * [[java.sql.PreparedStatement]] syntax (with one or more '?').
-   *
-   * @param statement SQL statement (with %s placeholders)
-   * @param frag Statement fragment
-   * @return Some rewrited statement, or None if there no available placeholder
-   *
-   * {{{
-   * Sql.rewrite("SELECT * FROM Test WHERE cat IN (%s)", "?, ?")
-   * // Some("SELECT * FROM Test WHERE cat IN (?, ?)")
-   * }}}
-   */
-  private[anorm] def rewrite(stmt: String, frag: String): Option[String] = {
-    val idx = stmt.indexOf("%s")
-
-    if (idx == -1) None
-    else {
-      val parts = stmt.splitAt(idx)
-      Some(parts._1 + frag + parts._2.drop(2))
-    }
-  }
-
   @annotation.tailrec
-  private[anorm] def prepareQuery(sql: String, i: Int, ps: Seq[ParameterValue], vs: Seq[(Int, ParameterValue)]): (String, Seq[(Int, ParameterValue)]) = {
-    ps.headOption match {
-      case Some(p) =>
-        val st: (String, Int) = p.toSql(sql, i)
-        prepareQuery(st._1, st._2, ps.tail, vs :+ (i -> p))
-      case _ => (sql, vs)
-    }
+  private[anorm] def prepareQuery(stmt: TokenizedStatement, i: Int, ps: Seq[ParameterValue], vs: Seq[(Int, ParameterValue)]): (TokenizedStatement, Seq[(Int, ParameterValue)]) = ps.headOption match {
+    case Some(p) =>
+      val st: (TokenizedStatement, Int) = p.toSql(stmt, i)
+      prepareQuery(st._1, st._2, ps.tail, vs :+ (i -> p))
+    case _ => (stmt, vs)
   }
 }

--- a/src/main/scala/anorm/SimpleSql.scala
+++ b/src/main/scala/anorm/SimpleSql.scala
@@ -54,10 +54,11 @@ case class SimpleSql[T](sql: SqlQuery, params: Map[String, ParameterValue], defa
 
   @deprecated(message = "Use [[preparedStatement]]", since = "2.3.6")
   def getFilledStatement(connection: Connection, getGeneratedKeys: Boolean = false) = {
-    val st: (String, Seq[(Int, ParameterValue)]) = Sql.prepareQuery(
-      sql.statement, 0, sql.paramsInitialOrder.map(params), Nil)
+    val st: (TokenizedStatement, Seq[(Int, ParameterValue)]) = Sql.prepareQuery(
+      sql.stmt, 0, sql.paramsInitialOrder.map(params), Nil)
 
-    val stmt = if (getGeneratedKeys) connection.prepareStatement(st._1, java.sql.Statement.RETURN_GENERATED_KEYS) else connection.prepareStatement(st._1)
+    val psql = TokenizedStatement.toSql(st._1).get // TODO: Make it safe
+    val stmt = if (getGeneratedKeys) connection.prepareStatement(psql, java.sql.Statement.RETURN_GENERATED_KEYS) else connection.prepareStatement(psql)
 
     sql.timeout.foreach(stmt.setQueryTimeout(_))
 

--- a/src/test/scala/anorm/BatchSqlSpec.scala
+++ b/src/test/scala/anorm/BatchSqlSpec.scala
@@ -274,7 +274,7 @@ object BatchSqlSpec
   }
 
   "Batch inserting" should {
-    "be success on test1 table" in withH2Database { implicit con =>
+    "be successful on test1 table" in withH2Database { implicit con =>
       createTest1Table()
 
       lazy val batch = BatchSql(
@@ -282,9 +282,10 @@ object BatchSqlSpec
           Seq[NamedParameter]('i -> 1, 'f -> "foo #1", 'b -> 2),
           Seq[NamedParameter]('i -> 2, 'f -> "foo_2", 'b -> 4)))
 
-      (batch.sql.statement aka "parsed statement" mustEqual (
-        "INSERT INTO test1(id, foo, bar) VALUES(%s, %s, %s)")).
-        and(batch.execute() aka "batch result" mustEqual Array(1, 1))
+      val stmt = TokenizedStatement(List(TokenGroup(List(StringToken("INSERT INTO test1(id, foo, bar) VALUES(")), Some("i")), TokenGroup(List(StringToken(", ")), Some("f")), TokenGroup(List(StringToken(", ")), Some("b")), TokenGroup(List(StringToken(")")), None)), List("i", "f", "b"))
+
+      batch.sql.stmt aka "parsed statement" mustEqual stmt and (
+        batch.execute() aka "batch result" mustEqual Array(1, 1))
     }
   }
 }

--- a/tokenizer/build.sbt
+++ b/tokenizer/build.sbt
@@ -1,0 +1,5 @@
+name := "anorm-tokenizer"
+
+libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value
+)

--- a/tokenizer/src/main/scala/anorm/TokenizedStatement.scala
+++ b/tokenizer/src/main/scala/anorm/TokenizedStatement.scala
@@ -1,0 +1,139 @@
+package anorm
+
+import scala.util.{ Failure, Try, Success }
+
+trait Show {
+  def show: String
+}
+
+private[anorm] sealed trait StatementToken
+private[anorm] case class StringToken(value: String) extends StatementToken
+private[anorm] case object PercentToken extends StatementToken
+
+private[anorm] case class TokenGroup(
+  /** Already prepared tokens, not requiring to rewrite placeholder. */
+  prepared: List[StatementToken],
+
+  /** Optional placeholder (name), after already prepared tokens */
+  placeholder: Option[String])
+
+private[anorm] case class TokenizedStatement(
+  /** Token groups */
+  tokens: List[TokenGroup],
+
+  /** Binding names of parsed placeholders */
+  names: List[String])
+
+private[anorm] object TokenizedStatement {
+  import java.util.StringTokenizer
+  import scala.collection.JavaConverters.enumerationAsScalaIteratorConverter
+  import scala.reflect.macros.Context
+  import scala.language.experimental.macros
+
+  /** Returns empty tokenized statement. */
+  lazy val empty = TokenizedStatement(Nil, Nil)
+
+  /** String interpolation to tokenize statement. */
+  def stringInterpolation[T](parts: Seq[String], params: Seq[T with Show]): (TokenizedStatement, Map[String, T]) = macro tokenizeImpl[T]
+
+  /** Tokenization macro */
+  def tokenizeImpl[T: c.WeakTypeTag](c: Context)(parts: c.Expr[Seq[String]], params: c.Expr[Seq[T with Show]]): c.Expr[(TokenizedStatement, Map[String, T])] =
+    c.universe.reify(tokenize(Iterator[String](), Nil, parts.splice,
+      params.splice, Nil, Nil, Map.empty[String, T]))
+
+  @annotation.tailrec
+  private[anorm] def tokenize[T](ti: Iterator[String], tks: List[StatementToken], parts: Seq[String], ps: Seq[T with Show], gs: List[TokenGroup], ns: List[String], m: Map[String, T]): (TokenizedStatement, Map[String, T]) = if (ti.hasNext) ti.next match {
+    case "%" => tokenize(ti, PercentToken :: tks, parts, ps, gs, ns, m)
+    case s: String =>
+      tokenize(ti, StringToken(s) :: tks, parts, ps, gs, ns, m)
+    case _ => /* should not occur */ tokenize(ti, tks, parts, ps, gs, ns, m)
+  }
+  else {
+    if (tks.nonEmpty) {
+      gs match {
+        case prev :: groups => ps.headOption match {
+          case Some(v) => prev match {
+            case TokenGroup(StringToken(str) :: gts, pl) if (
+              str endsWith "#" /* escaped part */ ) =>
+
+              val before = if (str == "#") gts.reverse else {
+                StringToken(str dropRight 1) :: gts.reverse
+              }
+              val ng = TokenGroup((tks ::: StringToken(v.show) ::
+                before), pl)
+
+              tokenize(ti, tks.tail, parts, ps.tail, (ng :: groups), ns, m)
+
+            case _ =>
+              val ng = TokenGroup(tks, None)
+              val n = '_'.toString + ns.size
+              tokenize(ti, tks.tail, parts, ps.tail,
+                (ng :: prev.copy(placeholder = Some(n)) :: groups),
+                (n :: ns), m + (n -> v))
+          }
+          case _ =>
+            sys.error(s"No parameter value for placeholder: ${gs.size}")
+        }
+        case _ => tokenize(ti, tks.tail, parts, ps,
+          List(TokenGroup(tks, None)), ns, m)
+      }
+    } else parts.headOption match {
+      case Some(part) =>
+        val it = new StringTokenizer(part, "%", true).
+          asScala.map(_.toString)
+
+        if (!it.hasNext /* empty */ ) {
+          tokenize(it, List(StringToken("")), parts.tail, ps, gs, ns, m)
+        } else tokenize(it, tks, parts.tail, ps, gs, ns, m)
+
+      case _ =>
+        val groups = ((gs match {
+          case TokenGroup(List(StringToken("")), None) :: tgs => tgs // trim end
+          case _ => gs
+        }) map {
+          case TokenGroup(pr, pl) => TokenGroup(pr.reverse, pl)
+        }).reverse
+
+        TokenizedStatement(groups, ns.reverse) -> m
+    }
+  }
+
+  /**
+   * Rewrites next placeholder in statement, with fragment using
+   * [[java.sql.PreparedStatement]] syntax (with one or more '?').
+   *
+   * @param stmt Tokenized statement
+   * @param frag Statement fragment
+   * @return Rewritten statement
+   *
+   * {{{
+   * Sql.rewrite("SELECT * FROM Test WHERE cat IN (%s)", "?, ?")
+   * // Some("SELECT * FROM Test WHERE cat IN (?, ?)")
+   * }}}
+   */
+  def rewrite(stmt: TokenizedStatement, frag: String): Try[TokenizedStatement] = stmt.tokens match {
+    case TokenGroup(pr, Some(pl)) :: gs =>
+      val prepared = pr :+ StringToken(frag)
+      Success(TokenizedStatement(gs match {
+        case TokenGroup(x, y) :: ts => TokenGroup(prepared ++ x, y) :: ts
+        case _ => TokenGroup(prepared, None) :: Nil
+      }, stmt.names))
+
+    case _ => Failure(new Exception("No more placeholder"))
+  }
+
+  /** Returns statement as SQL string. */
+  def toSql(stmt: TokenizedStatement): Try[String] = stmt.tokens match {
+    case TokenGroup(_, Some(pl)) :: _ =>
+      Failure(new IllegalStateException(s"Placeholder not prepared: $pl"))
+
+    case TokenGroup(pr, None) :: Nil => Success(pr.foldLeft("") {
+      case (sql, StringToken(t)) => sql + t
+      case (sql, PercentToken) => sql + '%'
+      case (sql, _) => sql
+    })
+
+    case _ =>
+      Failure(new IllegalStateException(s"Unexpected statement: $stmt"))
+  }
+}


### PR DESCRIPTION
- Avoid clash of reserved `%`: http://stackoverflow.com/questions/27697588/possible-bug-in-jdbc
- Make parsed statement more type safe
- No longer have to 'search' for placeholder to be prepared as SQL (as tokenized statement structure allows direct access to): runtime parsing (`SQL("...")`) has better performance, same performance for string interpolation (no more load at runtime due to this more complex/type safe tokenization, thanks to the macro helper).