### PR TITLE
Disable publishing of the root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,9 @@ lazy val java8 = project
   .enablePlugins(Omnidoc, Publish)
   .settings(javacOptions := Seq("-source", "1.8", "-target", "1.8"))
 
-lazy val root = Project(id = "anorm-parent", base = file(".")).
-  aggregate(tokenizer, anorm) configure { p =>
+lazy val root = Project(id = "anorm-parent", base = file("."))
+  .enablePlugins(NoPublish)
+  .aggregate(tokenizer, anorm) configure { p =>
     if (isJavaAtLeast("1.8")) p.aggregate(java8) else p
   }
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -65,3 +65,14 @@ object Publish extends AutoPlugin {
     ReleaseKeys.tagName := (version in ThisBuild).value
   )
 }
+
+object NoPublish extends AutoPlugin {
+  override def trigger = noTrigger
+  override def requires = JvmPlugin
+
+  override def projectSettings = Seq(
+    publish := (),
+    publishLocal := (),
+    publishTo := Some(Resolver.file("no-publish", crossTarget.value / "no-publish"))
+  )
+}


### PR DESCRIPTION
Nightly snapshots are failing when the root project tries to publish. Disable publishing completely (including for publishSigned).