### PR TITLE
BatchSql, NullPointerException with empty or missing parameters

### DIFF
--- a/core/src/test/scala/anorm/BatchSqlSpec.scala
+++ b/core/src/test/scala/anorm/BatchSqlSpec.scala
@@ -287,5 +287,16 @@ object BatchSqlSpec
       batch.sql.stmt aka "parsed statement" mustEqual stmt and (
         batch.execute() aka "batch result" mustEqual Array(1, 1))
     }
+
+    "not fail when there is no parameter" in {
+      var x: Boolean = false
+      implicit val con = AcolyteDSL.connection(
+        AcolyteDSL.handleStatement.withUpdateHandler {
+          case _ => x = true; 1
+        })
+
+      BatchSql("EXEC batch", Nil).execute().toList.
+        aka("batch result") must beEmpty and (x aka "executed" must beFalse)
+    }
   }
 }

--- a/core/src/test/scala/anorm/H2Database.scala
+++ b/core/src/test/scala/anorm/H2Database.scala
@@ -5,11 +5,10 @@ import scala.util.Random
 
 trait H2Database {
 
-  def withH2Database[R](block: Connection => R) = {
-    val dbName = "test" + Random.alphanumeric.take(6).mkString("")
+  def withH2Database[R](block: Connection => R): R = {
+    val url = "jdbc:h2:mem:test" + Random.alphanumeric.take(6).mkString("")
+    val connection = DriverManager.getConnection(url, "sa", "")
 
-    Class.forName("org.h2.Driver")
-    val connection = DriverManager.getConnection("jdbc:h2:mem:" + dbName, "sa", "")
     try {
       block(connection)
     } finally {


### PR DESCRIPTION
Anorm from play 2.3.7
Scala 2.11

    DB.withConnection { implicit c =>
        BatchSql(SQL("update sometable set something = 1600 where id = 2")).execute()
    }
explicitly: (even though Nil is default value for parameter)

    DB.withConnection { implicit c =>
        BatchSql(SQL("update sometable set something = 1600 where id = 2"), Nil).execute()
    }


My use case: 
`BatchSql(SQL("somesql"), aListThatMayOrMayNotBeEmpty))`

Expected:
If list is non-empty, run sql (in batch) with provided parameters, if list is empty, do nothing.

What happened:
`Execution exception[[NullPointerException: null]]`
Not very descriptive.

I spent way too much time on this just to come to the conclusion that parameters could not be an empty list (even though according to doc/source BatchSql defaults parameter "ps" to Nil)