### PR TITLE
Do not allow to prepare BatchSql with no list of parameter

### DIFF
--- a/Migration24.md
+++ b/Migration24.md
@@ -16,6 +16,19 @@ BatchSql("SQL")
 // Simpler and safer, as SqlQuery is created&validated internally
 ```
 
+Moreover, a first list of parameter (for the first execution item of the batch) will be mandatory.
+
+```scala
+import anorm.{ BatchSql, NamedParameter }
+
+val firstMandatory = Seq[NamedParameter]("a" -> 1, "b" -> 2)
+
+BatchSql("EXEC proc ?, ?", firstMandatory) // 1 execution item
+
+BatchSql("EXEC proc ?, ?", firstMandatory,
+  Seq[NamedParameter]("a" -> 3, "b" -> 4)) // 2 execution items
+```
+
 ## Execution
 
 The string interpolation in Anorm has been updated. By using `#$value` instead of `$value`, interpolated value will be part of the prepared statement, rather being passed as a parameter when executing this SQL statement (e.g. `#$cmd` and `#$table` in example bellow).

--- a/core/src/main/scala/anorm/BatchSql.scala
+++ b/core/src/main/scala/anorm/BatchSql.scala
@@ -165,8 +165,33 @@ sealed trait BatchSql {
 object BatchSql {
   @throws[IllegalArgumentException](BatchSqlErrors.HeterogeneousParameterMaps)
   @throws[IllegalArgumentException](BatchSqlErrors.ParameterNamesNotMatchingPlaceholders)
+  @deprecated(message = "Use `BatchSql(sql, first, other)`", since = "2.3.8")
   def apply(sql: String, ps: Seq[Seq[NamedParameter]] = Nil): BatchSql =
     Checked(SQL(sql), ps.map(_.map(_.tupled).toMap))
+
+  /**
+   * Creates a batch from given `sql` statement,
+   * with a `first` parameter list for for SQL execution, and zero or many
+   * `other` parameter lists for other SQL executions, after in the same batch.
+   *
+   * @param sql SQL statement
+   * @param first Parameter list for the first SQL execution
+   * @param other Parameter lists for other SQL executions in the same batch
+   *
+   * {{{
+   * import anorm.{ BatchSql, NamedParameter }
+   *
+   * BatchSql("EXEC proc ?, ?", // Batch with 1 execution
+   *   Seq[NamedParameter]("a" -> "Foo", "b" -> "Bar"))
+   *
+   * BatchSql("EXEC proc ?, ?", // Batch with 2 executions
+   *   Seq[NamedParameter]("a" -> "Foo", "b" -> "Bar"),
+   *   Seq[NamedParameter]("a" -> "Lorem", "b" -> "Ipsum"))
+   * }}}
+   */
+  @throws[IllegalArgumentException](BatchSqlErrors.HeterogeneousParameterMaps)
+  @throws[IllegalArgumentException](BatchSqlErrors.ParameterNamesNotMatchingPlaceholders)
+  def apply(sql: String, first: Seq[NamedParameter], other: Seq[NamedParameter]*): BatchSql = Checked(SQL(sql), (Seq(first) ++: other).map(_.map(_.tupled).toMap))
 
   @throws[IllegalArgumentException](BatchSqlErrors.HeterogeneousParameterMaps)
   @throws[IllegalArgumentException](BatchSqlErrors.ParameterNamesNotMatchingPlaceholders)

--- a/core/src/test/scala/anorm/BatchSqlSpec.scala
+++ b/core/src/test/scala/anorm/BatchSqlSpec.scala
@@ -12,8 +12,8 @@ object BatchSqlSpec
     "fail with parameter maps not having same names" in {
       lazy val batch = BatchSql(
         "SELECT * FROM tbl WHERE a = {a}",
-        Seq(Seq[NamedParameter]("a" -> 0),
-          Seq[NamedParameter]("a" -> 1, "b" -> 2)))
+        Seq[NamedParameter]("a" -> 0),
+        Seq[NamedParameter]("a" -> 1, "b" -> 2))
 
       batch aka "creation" must throwA[IllegalArgumentException](
         message = "Unexpected parameter names: a, b != expected a")
@@ -22,7 +22,7 @@ object BatchSqlSpec
     "fail with names not matching query placeholders" in {
       lazy val batch = BatchSql(
         "SELECT * FROM tbl WHERE a = {a}, b = {b}",
-        Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
+        Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3))
 
       batch.addBatch("a" -> 0).
         aka("append") must throwA[IllegalArgumentException](
@@ -32,8 +32,8 @@ object BatchSqlSpec
     "be successful with parameter maps having same names" in {
       lazy val batch = BatchSql(
         "SELECT * FROM tbl WHERE a = {a}, b = {b}",
-        Seq(Seq[NamedParameter]("a" -> 0, "b" -> -1),
-          Seq[NamedParameter]("a" -> 1, "b" -> 2)))
+        Seq[NamedParameter]("a" -> 0, "b" -> -1),
+        Seq[NamedParameter]("a" -> 1, "b" -> 2))
 
       lazy val expectedMaps = Seq(
         Map[String, ParameterValue]("a" -> 0, "b" -> -1),
@@ -49,7 +49,7 @@ object BatchSqlSpec
     "fail with unexpected name" in {
       val batch = BatchSql(
         "SELECT * FROM tbl WHERE a = {a}, b = {b}",
-        Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2)))
+        Seq[NamedParameter]("a" -> 1, "b" -> 2))
 
       batch.addBatch("a" -> 0, "c" -> 4).
         aka("append") must throwA[IllegalArgumentException](
@@ -59,7 +59,7 @@ object BatchSqlSpec
     "fail with missing names" in {
       val batch = BatchSql(
         "SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
-        Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
+        Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3))
 
       batch.addBatch("a" -> 0).
         aka("append") must throwA[IllegalArgumentException](
@@ -68,8 +68,7 @@ object BatchSqlSpec
 
     "with first parameter map" >> {
       "fail if parameter names not matching query placeholders" in {
-        val batch = BatchSql(
-          "SELECT * FROM tbl WHERE a = {a}, b = {b}")
+        val batch = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
         batch.addBatch("a" -> 0).
           aka("append") must throwA[IllegalArgumentException](
@@ -78,9 +77,7 @@ object BatchSqlSpec
       }
 
       "be successful" in {
-        val b1 = BatchSql(
-          "SELECT * FROM tbl WHERE a = {a}, b = {b}")
-
+        val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
         lazy val b2 = b1.addBatch("a" -> 0, "b" -> 1)
 
         lazy val expectedMaps =
@@ -92,9 +89,8 @@ object BatchSqlSpec
     }
 
     "be successful" in {
-      val b1 = BatchSql(
-        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
-        Seq(Seq[NamedParameter]("a" -> 0, "b" -> 1)))
+      val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}",
+        Seq[NamedParameter]("a" -> 0, "b" -> 1))
 
       lazy val b2 = b1.addBatch("a" -> 2, "b" -> 3)
 
@@ -109,9 +105,8 @@ object BatchSqlSpec
 
   "Appending list of list of named parameters" should {
     "fail with unexpected name" in {
-      val batch = BatchSql(
-        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
-        Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2)))
+      val batch = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}",
+        Seq[NamedParameter]("a" -> 1, "b" -> 2))
 
       batch.addBatchList(Seq(Seq("a" -> 0, "c" -> 4))).
         aka("append all") must throwA[IllegalArgumentException](
@@ -121,7 +116,7 @@ object BatchSqlSpec
     "fail with missing names" in {
       val batch = BatchSql(
         "SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
-        Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
+        Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3))
 
       batch.addBatchList(Seq(Seq("a" -> 0))).
         aka("append all") must throwA[IllegalArgumentException](
@@ -131,7 +126,6 @@ object BatchSqlSpec
     "with first parameter map" >> {
       "be successful" in {
         val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
-
         lazy val b2 = b1.addBatchList(Seq(Seq("a" -> 0, "b" -> 1)))
 
         lazy val expectedMaps =
@@ -142,9 +136,7 @@ object BatchSqlSpec
       }
 
       "fail with parameter maps not having same names" in {
-        val b1 = BatchSql(
-          "SELECT * FROM tbl WHERE a = {a}")
-
+        val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}")
         lazy val b2 = b1.addBatchList(Seq(
           Seq("a" -> 0), Seq("a" -> 1, "b" -> 2)))
 
@@ -181,9 +173,8 @@ object BatchSqlSpec
     }
 
     "be successful" in {
-      val b1 = BatchSql(
-        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
-        Seq(Seq("a" -> 0, "b" -> 1)))
+      val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}",
+        Seq[NamedParameter]("a" -> 0, "b" -> 1))
 
       lazy val b2 = b1.addBatchList(Seq(Seq("a" -> 2, "b" -> 3)))
 
@@ -198,9 +189,7 @@ object BatchSqlSpec
 
   "Appending list of parameter values" should {
     "be successful with first parameter map" in {
-      val b1 = BatchSql(
-        "SELECT * FROM tbl WHERE a = {a}, b = {b}")
-
+      val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
       lazy val b2 = b1.addBatchParams(0, 1)
       lazy val expectedMaps =
         Seq(Map[String, ParameterValue]("a" -> 0, "b" -> 1))
@@ -210,8 +199,7 @@ object BatchSqlSpec
     }
 
     "fail with missing argument" in {
-      val b1 = BatchSql(
-        "SELECT * FROM tbl WHERE a = {a}, b = {b}").
+      val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}").
         addBatchParams(0, 1)
 
       lazy val b2 = b1.addBatchParams(2)
@@ -221,8 +209,7 @@ object BatchSqlSpec
     }
 
     "be successful" in {
-      val b1 = BatchSql(
-        "SELECT * FROM tbl WHERE a = {a}, b = {b}")
+      val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
       lazy val b2 = b1.addBatchParams(0, 1).addBatchParams(2, 3)
       lazy val expectedMaps = Seq(
@@ -278,9 +265,9 @@ object BatchSqlSpec
       createTest1Table()
 
       lazy val batch = BatchSql(
-        "INSERT INTO test1(id, foo, bar) VALUES({i}, {f}, {b})", Seq(
-          Seq[NamedParameter]('i -> 1, 'f -> "foo #1", 'b -> 2),
-          Seq[NamedParameter]('i -> 2, 'f -> "foo_2", 'b -> 4)))
+        "INSERT INTO test1(id, foo, bar) VALUES({i}, {f}, {b})",
+        Seq[NamedParameter]('i -> 1, 'f -> "foo #1", 'b -> 2),
+        Seq[NamedParameter]('i -> 2, 'f -> "foo_2", 'b -> 4))
 
       val stmt = TokenizedStatement(List(TokenGroup(List(StringToken("INSERT INTO test1(id, foo, bar) VALUES(")), Some("i")), TokenGroup(List(StringToken(", ")), Some("f")), TokenGroup(List(StringToken(", ")), Some("b")), TokenGroup(List(StringToken(")")), None)), List("i", "f", "b"))
 
@@ -295,7 +282,7 @@ object BatchSqlSpec
           case _ => x = true; 1
         })
 
-      BatchSql("EXEC batch", Nil).execute().toList.
+      BatchSql("EXEC batch", Seq.empty[Seq[NamedParameter]]).execute().toList.
         aka("batch result") must beEmpty and (x aka "executed" must beFalse)
     }
   }

--- a/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
+++ b/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
@@ -364,13 +364,14 @@ import anorm.BatchSql
 
 val batch = BatchSql(
   "INSERT INTO books(title, author) VALUES({title}, {author}", 
-  Seq(Seq[NamedParameter](
-    "title" -> "Play 2 for Scala", "author" -> Peter Hilton"),
-    Seq[NamedParameter]("title" -> "Learning Play! Framework 2",
-      "author" -> "Andy Petrella")))
+  Seq[NamedParameter]("title" -> "Play 2 for Scala", "author" -> Peter Hilton"),
+  Seq[NamedParameter]("title" -> "Learning Play! Framework 2",
+    "author" -> "Andy Petrella"))
 
 val res: Array[Int] = batch.execute() // array of update count
 ```
+
+> Batch update must be called with at least one list of parameter. If a batch is executed with the mandatory first list of parameter being empty (e.g. `Nil`), only one statement will be executed (without parameter), which is equivalent to `SQL(statement).executeUpdate()`.
 
 ### Edge cases
 


### PR DESCRIPTION
Require at least one (first) list of parameters.

```scala
BatchSql("...", Seq[NamedParameter](...), ...)
```