### PR TITLE
Row.asList & .asMap are needlessly O(N^2) in the number of columns

### DIFF
--- a/core/src/main/scala/anorm/Cursor.scala
+++ b/core/src/main/scala/anorm/Cursor.scala
@@ -77,6 +77,6 @@ object Cursor {
   private case class ResultRow(
       metaData: MetaData, data: List[Any]) extends Row {
 
-    override lazy val toString = "Row(" + metaData.ms.zip(data).map(t => s"'${t._1.column}': ${t._2} as ${t._1.clazz}").mkString(", ") + ")"
+    override lazy val toString = "Row(" + (metaData.ms, data).zipped.map((m, v) => s"'${m.column}': ${v} as ${m.clazz}").mkString(", ") + ")"
   }
 }


### PR DESCRIPTION
[Row.asList](https://github.com/playframework/anorm/blob/master/core/src/main/scala/anorm/Row.scala#L22) is currently defined as: 
````
lazy val asList: List[Any] = data.foldLeft[List[Any]](Nil) { (l, v) =>
    if (metaData.ms(l.size).nullable) l :+ Option(v) else l :+ v
  }
````
This code loops over `data` (= list with num_columns items in it), then build a transformed result list that is both queried for size (= O(N) each time), and _appended_ to (again O(N) each time). 

We also index into `metaData.ms` (a list with num_columns of items), which is again O(N). 

Since we do O(N) operations O(N) times, this makes the overall time complexity O(N^2).  

Rewriting this to something like: 
````
  lazy val asList: List[Any] = {
    (data, metaData.ms).zipped.map((field, meta) => if (meta.nullable) Option(field) else field)
  }
````
Should resolve the issue and maybe make what's going on a little more clear? 

Similarly for [Row.asMap](https://github.com/playframework/anorm/blob/master/core/src/main/scala/anorm/Row.scala#L37):
````
  lazy val asMap: Map[String, Any] =
    data.foldLeft[Map[String, Any]](Map.empty) { (m, v) =>
      val d = metaData.ms(m.size)
      val k = d.column.qualified
      if (d.nullable) m + (k -> Option(v)) else m + (k -> v)
    }
````
It indexes `metaData.ms` again, and builds an immutable map one item at a time without a builder / buffer. 

Changing it to: 
````
  lazy val asMap: Map[String, Any] =
    (data, metaData.ms).zipped.map((field, meta) => {
      meta.column.qualified -> (if (meta.nullable) Option(field) else field)
    }).toMap
````
Should resolve the issue. 

(sorry, not good with PRs...)