### PR TITLE
Provide a shorter syntax to write RowParser for a case class 

### DIFF
--- a/Migration24.md
+++ b/Migration24.md
@@ -116,6 +116,17 @@ val optionalParseRes =
 
 Compatibility is added for JDBC driver exposing degraded ResultSet (not respecting JDBC specs about row iteration, like Oracle one).
 
+A function can be directly applied on columns with parser combinator `to`.
+
+```scala
+import anorm.SqlParser.{ int, str, to }
+
+def display(name: String, population: Int): String = 
+  s"The population in $name is of $population."
+
+val parser = str("name") ~ int("population") map (to(display _))
+```
+
 ## Type mappings
 
 More parameter and column conversions are available.

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import scala.util.Properties.isJavaAtLeast
+import AnormGeneration.{ generateFunctionAdapter => GFA }
 
 lazy val tokenizer = project
   .in(file("tokenizer"))
@@ -7,6 +8,10 @@ lazy val tokenizer = project
 lazy val anorm = project
   .in(file("core"))
   .enablePlugins(Playdoc, Omnidoc, Publish)
+  .settings({
+    sourceGenerators in Compile <+= (
+      sourceManaged in Compile).map(m => Seq(GFA(m / "anorm")))
+  })
   .settings({
     libraryDependencies ++= Seq(
       "com.jsuereth" %% "scala-arm" % "1.4",

--- a/core/src/main/scala/anorm/SqlParser.scala
+++ b/core/src/main/scala/anorm/SqlParser.scala
@@ -3,7 +3,7 @@
  */
 package anorm
 
-object SqlParser {
+object SqlParser extends FunctionAdapter {
   import MayErr._
   import java.io.InputStream
   import java.util.Date

--- a/core/src/test/scala/anorm/FunctionAdapterSpec.scala
+++ b/core/src/test/scala/anorm/FunctionAdapterSpec.scala
@@ -7,237 +7,250 @@ import acolyte.jdbc.Rows._
 import acolyte.jdbc.AcolyteDSL.withQueryResult
 import acolyte.jdbc.Implicits._
 
-object TupleFlattenerSpec extends org.specs2.mutable.Specification {
-  "Tuple flattener" title
+object FunctionAdapterSpec extends org.specs2.mutable.Specification {
+  "Function flattener" title
+
+  "Single column" should {
+    "be applied with parser function" in withQueryResult(intList :+ 123) {
+      implicit c =>
+        SQL("SELECT * FROM test").as(
+          int(1) map (SqlParser.to(_.toString)) single) must_== "123"
+    }
+  }
 
   "Raw tuple-like" should {
-    "be flatten from 2 columns to Tuple2" in {
+    "be applied with 2 columns to Function2" in {
+      def foo(a: String, b: Int) = "Fn2"
       val schema = rowList2(classOf[String] -> "A", classOf[Int] -> "B")
 
       withQueryResult(schema :+ ("A", 2)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple2("A", 2)
+          str("A") ~ int("B") map (SqlParser.to(foo _)) single).
+          aka("function result") must_== "Fn2"
 
       }
     }
 
-    "be flatten from 3 columns to Tuple3" in {
+    "be applied with 3 columns to Function3" in {
+      case class Foo(a: String, b: Int, c: Long)
       val schema = rowList3(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C")
 
-      withQueryResult(schema :+ ("A", 2, 3l)) { implicit c =>
+      withQueryResult(schema :+ ("A", 2, 3L)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple3("A", 2, 3l)
+          str("A") ~ int("B") ~ long("C") map (
+            SqlParser.to(Foo.apply _)) single).
+          aka("function result") must_== Foo("A", 2, 3L)
 
       }
     }
 
-    "be flatten from 4 columns to Tuple4" in {
+    "be applied with 4 columns to Function4" in {
+      def foo(a: String, b: Int, c: Long, d: Double) = "Fn4"
       val schema = rowList4(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple4("A", 2, 3l, 4.56d)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") map (SqlParser.to(foo _)) single).
+          aka("function result") must_== "Fn4"
 
       }
     }
 
-    "be flatten from 5 columns to Tuple5" in {
+    "be applied with 5 columns to Function5" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short) = "Fn5"
       val schema = rowList5(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple5("A", 2, 3l, 4.56d, 9.toShort)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") map (SqlParser.to(foo _)) single).
+          aka("function result") must_== "Fn5"
 
       }
     }
 
-    "be flatten from 6 columns to Tuple6" in {
+    "be applied with 6 columns to Function6" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte) = "Fn6"
       val schema = rowList6(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple6("A", 2, 3l, 4.56d, 9.toShort, 10.toByte)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") map (SqlParser.to(foo _)) single).
+          aka("function result") must_== "Fn6"
 
       }
     }
 
-    "be flatten from 7 columns to Tuple7" in {
+    "be applied with 7 columns to Function7" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean) = "Fn7"
       val schema = rowList7(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple7("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn7"
 
       }
     }
 
-    "be flatten from 8 columns to Tuple8" in {
+    "be applied with 8 columns to Function8" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String) = "Fn8"
       val schema = rowList8(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B")) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple8("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B")
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn8"
 
       }
     }
 
-    "be flatten from 9 columns to Tuple9" in {
+    "be applied with 9 columns to Function9" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int) = "Fn9"
       val schema = rowList9(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple9("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn9"
 
       }
     }
 
-    "be flatten from 10 columns to Tuple10" in {
+    "be applied with 10 columns to Function10" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long) = "Fn10"
       val schema = rowList10(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple10("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn10"
 
       }
     }
 
-    "be flatten from 11 columns to Tuple11" in {
+    "be applied with 11 columns to Function11" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double) = "Fn11"
       val schema = rowList11(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple11("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn11"
 
       }
     }
 
-    "be flatten from 12 columns to Tuple12" in {
+    "be applied with 12 columns to Function12" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short) = "Fn12"
       val schema = rowList12(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple12("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn12"
 
       }
     }
 
-    "be flatten from 13 columns to Tuple13" in {
+    "be applied with 13 columns to Function13" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte) = "Fn13"
       val schema = rowList13(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple13("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") map (SqlParser.to(foo _)) single).
+          aka("function result") must_== "Fn13"
 
       }
     }
 
-    "be flatten from 14 columns to Tuple14" in {
+    "be applied with 14 columns to Function14" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte, n: Boolean) = "Fn14"
       val schema = rowList14(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M", classOf[Boolean] -> "N")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple14("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn14"
 
       }
     }
 
-    "be flatten from 15 columns to Tuple15" in {
+    "be applied with 15 columns to Function15" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte, n: Boolean, o: String) = "Fn15"
       val schema = rowList15(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M", classOf[Boolean] -> "N", classOf[String] -> "O")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C")) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple15("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C")
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn15"
 
       }
     }
 
-    "be flatten from 16 columns to Tuple16" in {
+    "be applied with 16 columns to Function16" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte, n: Boolean, o: String, p: Int) = "Fn16"
       val schema = rowList16(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M", classOf[Boolean] -> "N", classOf[String] -> "O", classOf[Int] -> "P")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple16("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn16"
 
       }
     }
 
-    "be flatten from 17 columns to Tuple17" in {
+    "be applied with 17 columns to Function17" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte, n: Boolean, o: String, p: Int, q: Long) = "Fn17"
       val schema = rowList17(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M", classOf[Boolean] -> "N", classOf[String] -> "O", classOf[Int] -> "P", classOf[Long] -> "Q")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple17("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn17"
 
       }
     }
 
-    "be flatten from 18 columns to Tuple18" in {
+    "be applied with 18 columns to Function18" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte, n: Boolean, o: String, p: Int, q: Long, r: Double) = "Fn18"
       val schema = rowList18(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M", classOf[Boolean] -> "N", classOf[String] -> "O", classOf[Int] -> "P", classOf[Long] -> "Q", classOf[Double] -> "R")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple18("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn18"
 
       }
     }
 
-    "be flatten from 19 columns to Tuple19" in {
+    "be applied with 19 columns to Function19" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte, n: Boolean, o: String, p: Int, q: Long, r: Double, s: Short) = "Fn19"
       val schema = rowList19(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M", classOf[Boolean] -> "N", classOf[String] -> "O", classOf[Int] -> "P", classOf[Long] -> "Q", classOf[Double] -> "R", classOf[Short] -> "S")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d, 16.toShort)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") ~ get[Short]("S") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple19("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d, 16.toShort)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") ~ get[Short]("S") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn19"
 
       }
     }
 
-    "be flatten from 20 columns to Tuple20" in {
+    "be applied with 20 columns to Function20" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte, n: Boolean, o: String, p: Int, q: Long, r: Double, s: Short, t: String) = "Fn20"
       val schema = rowList20(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M", classOf[Boolean] -> "N", classOf[String] -> "O", classOf[Int] -> "P", classOf[Long] -> "Q", classOf[Double] -> "R", classOf[Short] -> "S", classOf[String] -> "T")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d, 16.toShort, "D")) { implicit c =>
-        SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") ~ get[Short]("S") ~ str("T") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple20("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d, 16.toShort, "D")
+        SQL("SELECT * FROM test").as(str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") ~ get[Short]("S") ~ str("T") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn20"
 
       }
     }
 
-    "be flatten from 21 columns to Tuple21" in {
+    "be applied with 21 columns to Function21" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte, n: Boolean, o: String, p: Int, q: Long, r: Double, s: Short, t: String, u: Int) = "Fn21"
       val schema = rowList21(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M", classOf[Boolean] -> "N", classOf[String] -> "O", classOf[Int] -> "P", classOf[Long] -> "Q", classOf[Double] -> "R", classOf[Short] -> "S", classOf[String] -> "T", classOf[Int] -> "U")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d, 16.toShort, "D", 4)) { implicit c =>
-        SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") ~ get[Short]("S") ~ str("T") ~ int("U") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple21("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d, 16.toShort, "D", 4)
+        SQL("SELECT * FROM test").as(str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") ~ get[Short]("S") ~ str("T") ~ int("U") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn21"
 
       }
     }
 
-    "be flatten from 22 columns to Tuple22" in {
+    "be applied with 22 columns to Function22" in {
+      def foo(a: String, b: Int, c: Long, d: Double, e: Short, f: Byte, g: Boolean, h: String, i: Int, j: Long, k: Double, l: Short, m: Byte, n: Boolean, o: String, p: Int, q: Long, r: Double, s: Short, t: String, u: Int, v: Long) = "Fn22"
       val schema = rowList22(classOf[String] -> "A", classOf[Int] -> "B", classOf[Long] -> "C", classOf[Double] -> "D", classOf[Short] -> "E", classOf[Byte] -> "F", classOf[Boolean] -> "G", classOf[String] -> "H", classOf[Int] -> "I", classOf[Long] -> "J", classOf[Double] -> "K", classOf[Short] -> "L", classOf[Byte] -> "M", classOf[Boolean] -> "N", classOf[String] -> "O", classOf[Int] -> "P", classOf[Long] -> "Q", classOf[Double] -> "R", classOf[Short] -> "S", classOf[String] -> "T", classOf[Int] -> "U", classOf[Long] -> "V")
 
       withQueryResult(schema :+ ("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d, 16.toShort, "D", 4, 5l)) { implicit c =>
         SQL("SELECT * FROM test").as(
-          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") ~ get[Short]("S") ~ str("T") ~ int("U") ~ long("V") map (SqlParser.flatten) single).
-          aka("flatten columns") must_== Tuple22("A", 2, 3l, 4.56d, 9.toShort, 10.toByte, true, "B", 3, 4l, 5.67d, 10.toShort, 11.toByte, false, "C", 3, 4l, 5.678d, 16.toShort, "D", 4, 5l)
+          str("A") ~ int("B") ~ long("C") ~ get[Double]("D") ~ get[Short]("E") ~ get[Byte]("F") ~ bool("G") ~ str("H") ~ int("I") ~ long("J") ~ get[Double]("K") ~ get[Short]("L") ~ get[Byte]("M") ~ bool("N") ~ str("O") ~ int("P") ~ long("Q") ~ get[Double]("R") ~ get[Short]("S") ~ str("T") ~ int("U") ~ long("V") map (SqlParser.to(foo _)) single).aka("function result") must_== "Fn22"
 
       }
     }

--- a/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
+++ b/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
@@ -614,7 +614,7 @@ val populations: List[String ~ Int] =
   SQL("SELECT * FROM Country").as((str("name") ~ int("population")).*) 
 ```
 
-As you see, this query’s result type is `List[String~Int]` - a list of country name and population items.
+As you see, this query’s result type is `List[String ~ Int]` - a list of country name and population items.
 
 You can also rewrite the same code as:
 
@@ -638,6 +638,19 @@ Now, because transforming `A ~ B ~ C` types to `(A, B, C)` is a common task, we 
 val result: List[(String, Int)] = 
   SQL("select * from Country").as(parser.flatten.*)
 ```
+
+A `RowParser` can be combined with any function to applied it with extracted columns.
+
+```scala
+import anorm.SqlParser.{ int, str, to }
+
+def display(name: String, population: Int): String = 
+  s"The population in $name is of $population."
+
+val parser = str("name") ~ int("population") map (to(display _))
+```
+
+> **Note:** The mapping function must be partially applied (syntax `fn _`) when given `to` the parser (see [SLS 6.26.2, 6.26.5 - Eta expansion](http://www.scala-lang.org/docu/files/ScalaReference.pdf)).
 
 If list should not be empty, `parser.+` can be used instead of `parser.*`.
 

--- a/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
+++ b/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
@@ -5,8 +5,9 @@ import play.api.test._
 import play.api.test.Helpers._
 
 object ScalaAnorm extends Specification {
+  "Code samples" title
 
-  "anorm" should {
+  "Anorm" should {
     "be usable in play" in new WithApplication(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       //#playdb
       import anorm._
@@ -19,5 +20,4 @@ object ScalaAnorm extends Specification {
       ok
     }
   }
-
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -14,7 +14,7 @@ object Common extends AutoPlugin {
     organization := "com.typesafe.play",
 
     scalaVersion := sys.props.get("scala.version").getOrElse("2.10.4"),
-    crossScalaVersions := Seq("2.10.4", "2.11.3"),
+    crossScalaVersions := Seq("2.10.4", "2.11.4"),
 
     scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8"),
     (javacOptions in compile) := Seq("-source", "1.7", "-target", "1.7"),
@@ -28,6 +28,58 @@ object Common extends AutoPlugin {
       "http://dl.bintray.com/scalaz/releases" // specs2 depends on scalaz-stream
     }
   )
+}
+
+object AnormGeneration {
+  def generateFunctionAdapter(dir: File): File = {
+    val out = dir / "FunctionAdapter.scala"
+
+    if (out exists) out else {
+      IO.writer[File](out, "", IO.defaultCharset, false) { w ⇒
+        w.append("""package anorm
+
+/** Function adapters to work with extract data. */
+private[anorm] trait FunctionAdapter {
+  /**
+   * Returns function application with a single column.
+   * @tparam T1 the type of column
+   * @tparam R the type of result from `f` applied with the column
+   * @param f the function applied with column
+   */
+  def to[T1, R](f: Function1[T1, R]): T1 => R = f""")
+
+        (2 to 22).foreach { i =>
+          val values = (1 to i).map(j => s"c$j")
+          val types = (1 to i).map(j => s"T$j")
+
+          w.append("""
+
+  /**
+   * Returns function applicable with a $i-column tuple-like.""")
+
+          (1 to i).foreach { j =>
+            w.append(s"""
+   * @tparam T$j the type of column #$j""")
+          }
+
+          w.append("""
+   * @tparam R the type of result from `f` applied with the columns
+   * @param f the function applied with columns
+   */
+  def to[""")
+
+          (1 to i).foreach { j => w.append(s"T$j, ") }
+
+          w.append(s"R](f: Function$i[${types mkString ", "}, R]): ${types mkString " ~ "} => R = { case ${values mkString " ~ "} => f(${values mkString ", "}) }")
+        }
+
+        w.append("""
+}""")
+
+        out
+      }
+    }
+  }
 }
 
 object Publish extends AutoPlugin {


### PR DESCRIPTION
I have the following case case and I want to create a RowParser:

```scala
case class History(date: Date, code: String, comment: String)

object History {
  val simple = {
    get[Date]("date") ~ get[String]("code") ~ get[String]("comment") map {
      case date ~ code ~ comment => History(date, code, comment)
    }
  }
}
```

I can use `flatten` to transform `A~B~C` types to `(A,B,C)` and then use `tupled` but the syntax is a bit long and complicated:
```scala
val simple = {
  (get[Date]("date") ~ get[String]("code") ~ get[String]("comment") map flatten) map (History.apply _ tupled)
} 
```
If I don't redefine the companion object it's a little bit better:
```scala
val simple = {
  get[Date]("date") ~ get[String]("code") ~ get[String]("comment") map flatten map History.tupled
}
```

But it would be great if we could reduce the syntax to avoid the double `map`. Do you think this is possible ?


Thanks