### PR TITLE
Anorm joda DateTime to statement conversion is not working

### DIFF
--- a/Migration24.md
+++ b/Migration24.md
@@ -222,6 +222,8 @@ ZonedDateTime<sup>4</sup> | Timestamp
 - 3. Type `org.joda.time.LocalDateTime`.
 - 4. Type `org.joda.time.ZonedDateTime`.
 
+To enable Joda types as parameter, the `import anorm.JodaParameterMetaData._` must be used.
+
 These types are also supported in column mappings.
 
 Column (JDBC type)    | (as) JVM/Scala type

--- a/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
+++ b/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
@@ -984,6 +984,8 @@ ZonedDateTime<sup>4</sup> | Timestamp
 - 3. Type `org.joda.time.LocalDateTime`.
 - 4. Type `org.joda.time.ZonedDateTime`
 
+To enable Joda types as parameter, the `import anorm.JodaParameterMetaData._` must be used.
+
 Custom or specific DB conversion for parameter can also be provided:
 
 ```


### PR DESCRIPTION
Hi,

I finally upgraded to Anorm 2.4, to get rid off the [manual joda DateTime conversion](http://stackoverflow.com/questions/11388301/joda-datetime-field-on-play-framework-2-0s-anorm).  However, for me it does not work. Consider the following example:

    import anorm.SqlParser._
    import anorm._
    import org.joda.time.DateTime 
    import play.api.Play.current
    import play.api.db.DB

    DB.withConnection { implicit connection =>
         SQL("""SELECT id, entity1 AS e1, entity2 AS e2, dayFrequency as frequency, date
                FROM relationships r
                WHERE r.id = {id} AND date = {date}""").on(
               'id -> id,
              'date -> date).as(simple.singleOpt)
        }
     }

Which yields the following error:

    found   : (Symbol, org.joda.time.DateTime)
    [error]  required: anorm.NamedParameter
    [error]           'date -> date).as(simple.singleOpt)
    [error]                 ^
    [error] one error found

With the import for the manual AnormExtension provided in the link is works.

Best Uli 
