### PR TITLE
Batch Sql - minor docs improvement

### DIFF
--- a/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
+++ b/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
@@ -363,9 +363,10 @@ When you need to execute SQL statement several times with different arguments, b
 import anorm.BatchSql
 
 val batch = BatchSql(
-  "INSERT INTO books(title, author) VALUES({title}, {author}", 
-  Seq[NamedParameter]("title" -> "Play 2 for Scala", "author" -> Peter Hilton"),
-  Seq[NamedParameter]("title" -> "Learning Play! Framework 2",
+  "INSERT INTO books(title, author) VALUES({title}, {author})", 
+  Seq[NamedParameter]("title" -> "Play 2 for Scala", 
+    "author" -> "Peter Hilton"),
+  Seq[NamedParameter]("title" -> "Learning Play! Framework 2", 
     "author" -> "Andy Petrella"))
 
 val res: Array[Int] = batch.execute() // array of update count


### PR DESCRIPTION
Sample code in docs for BatchSql is broken. Changed:

```
was: VALUES({title}, {author}
now: VALUES({title}, {author})

was: -> Peter Hilton"
now: -> "Peter Hilton"
```
