### PR TITLE
Executing a query with .executeInsert() over a table without auto-generated key produces a NullPointerException.

### DIFF
--- a/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
+++ b/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
@@ -480,6 +480,11 @@ To handle such edge-case, `.withResultSetOnFirstRow(true)` can be used as follow
 ```scala
 SQL("EXEC stored_proc {arg}").on("arg" -> "val").withResultSetOnFirstRow(true)
 SQL"""EXEC stored_proc ${"val"}""".withResultSetOnFirstRow(true)
+
+SQL"INSERT INTO dict(term, definition) VALUES ($term, $definition)".
+  withResultSetOnFirstRow(true).executeInsert()
+// Also needed on executeInsert for such driver, 
+// as a ResultSet is returned in this case for the generated keys
 ```
 
 ## Using Pattern Matching


### PR DESCRIPTION
- Oracle jdbc driver : ojdbc7
- Anorm version : 2.3.9
- Stack error : 

Caused by: java.lang.NullPointerException: null
	at oracle.jdbc.driver.AutoKeyInfo.initMetaDataKeyFlag(AutoKeyInfo.java:404) ~[ojdbc7.jar:12.1.0.1.0]
	at oracle.jdbc.driver.AutoKeyInfo.initMetaData(AutoKeyInfo.java:392) ~[ojdbc7.jar:12.1.0.1.0]
	at oracle.jdbc.driver.OracleReturnResultSet.getMetaData(OracleReturnResultSet.java:77) ~[ojdbc7.jar:12.1.0.1.0]
	at anorm.Sql$.metaData(Anorm.scala:448) ~[anorm_2.11-2.3.9.jar:2.3.9]
	at anorm.Sql$.resultSetToStream(Anorm.scala:483) ~[anorm_2.11-2.3.9.jar:2.3.9]

Running the insert with .executeUpdate() works fine.