### PR TITLE
Add public member metaDataItems to Row trait

### DIFF
--- a/core/src/main/scala/anorm/Row.scala
+++ b/core/src/main/scala/anorm/Row.scala
@@ -9,6 +9,11 @@ trait Row {
   private[anorm] val data: List[Any]
 
   /**
+   * Returns a list of metadata items, one for each column.
+   */
+  lazy val metaDataItems: List[MetaDataItem] = metaData.ms
+
+  /**
    * Returns row as list of column values.
    *
    * {{{

--- a/core/src/test/scala/anorm/RowSpec.scala
+++ b/core/src/test/scala/anorm/RowSpec.scala
@@ -9,6 +9,17 @@ import acolyte.jdbc.Implicits._
 object RowSpec extends org.specs2.mutable.Specification {
   "Row" title
 
+  "List of metadata items" should {
+    "include all columns" in withQueryResult(rowList2(
+      classOf[String] -> "foo", classOf[Int] -> "bar") :+ ("row1", 100)) {
+      implicit c =>
+        SQL("SELECT * FROM test").map(_.metaDataItems).single.
+          aka("metadata item list") must_== List(
+            MetaDataItem(ColumnName(".foo", Some("foo")), false, "java.lang.String"),
+            MetaDataItem(ColumnName(".bar", Some("bar")), false, "int"))
+    }
+  }
+
   "List of column values" should {
     "be expected one" in withQueryResult(rowList2(
       classOf[String] -> "foo", classOf[Int] -> "bar") :+ ("row1", 100)) {


### PR DESCRIPTION
This provides public access to column metadata, which is necessary when the developer does not know the number of columns in the result set or their names and data types, as demonstrated in #42.