### PR TITLE
A row parser that fold over row information

### DIFF
--- a/Highlights25.md
+++ b/Highlights25.md
@@ -3,4 +3,5 @@
 This page highlights the new features of Anorm 2.5. If you want learn about the changes you need to make to migrate to Anorm 2.5, check out the [[Migration Guide|Migration25]].
 
 - Row parser automatically generated for case classes: `Macro.namedParser[T]`, `Macro.indexedParser[T]` and `Macro.parser[T](names)`.
+- New `SqlParser.folder` to fold over "non-strict" row columns.
 - New numeric and temporal conversions.

--- a/Migration25.md
+++ b/Migration25.md
@@ -79,3 +79,18 @@ case class Info(name: String, year: Option[Int])
 val parser: RowParser[Info] = Macro.namedParser[Info]
 val result: List[Info] = SQL"SELECT * FROM list".as(parser.*)
 ```
+
+## Parsing
+
+The new `SqlParser.folder` make it possible to handle columns that are not strictly defined (e.g. with types that can vary).
+
+```scala
+import anorm.{ RowParser, SqlParser }
+
+val parser: RowParser[Map[String, Any]] =
+  SqlParser.folder(Map.empty[String, Any]) { (map, value, meta) =>
+    Right(map + (meta.column.qualified -> value))
+  }
+
+val result: List[Map[String, Any]] = SQL"SELECT * FROM dyn_table".as(parser.*)
+```

--- a/core/src/main/scala/anorm/Anorm.scala
+++ b/core/src/main/scala/anorm/Anorm.scala
@@ -54,8 +54,18 @@ case class TypeDoesNotMatch(reason: String) extends SqlRequestError {
  */
 case class Object(value: Any)
 
-case class MetaDataItem(column: ColumnName, nullable: Boolean, clazz: String)
+/**
+ * @param qualified the qualified column name
+ * @param alias the column alias
+ */
 case class ColumnName(qualified: String, alias: Option[String])
+
+/**
+ * @param column the name of the column
+ * @param nullable true if the column is nullable
+ * @param clazz the class of the JDBC column value
+ */
+case class MetaDataItem(column: ColumnName, nullable: Boolean, clazz: String)
 
 private[anorm] case class MetaData(ms: List[MetaDataItem]) {
   /** Returns meta data for specified column. */

--- a/core/src/test/scala/anorm/AnormSpec.scala
+++ b/core/src/test/scala/anorm/AnormSpec.scala
@@ -188,6 +188,14 @@ object AnormSpec extends Specification with H2Database with AnormTest {
 
       }
     }
+
+    "fold row" in withQueryResult(rows2) { implicit c =>
+      SQL("SELECT * FROM test").as(
+        SqlParser.folder(List.empty[(Any, String, String)])({ (ls, v, m) =>
+          Right((v, m.column.qualified, m.clazz) :: ls)
+        }).singleOpt) must beSome(
+          ("str", ".val", "java.lang.String") :: (2, ".id", "int") :: Nil)
+    }
   }
 
   "Instance of case class" should {

--- a/core/src/test/scala/anorm/SqlResultSpec.scala
+++ b/core/src/test/scala/anorm/SqlResultSpec.scala
@@ -101,19 +101,16 @@ object SqlResultSpec extends org.specs2.mutable.Specification with H2Database {
   "Column" should {
     "be matching in result" in withQueryResult(
       rowList1(classOf[Float] -> "f") :+ 1.2f) { implicit c =>
-
         SQL("SELECT f") as SqlParser.matches("f", 1.2f).single must beTrue
       }
 
     "not be found in result when value not matching" in withQueryResult(
       rowList1(classOf[Float] -> "f") :+ 1.2f) { implicit c =>
-
         SQL("SELECT f") as SqlParser.matches("f", 2.34f).single must beFalse
       }
 
     "not be found in result when column missing" in withQueryResult(
       rowList1(classOf[Float] -> "f") :+ 1.2f) { implicit c =>
-
         SQL("SELECT f") as SqlParser.matches("x", 1.2f).single must beFalse
       }
   }

--- a/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
+++ b/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
@@ -172,6 +172,19 @@ val product: (String, Float) = SQL("SELECT * FROM prod WHERE id = {id}").
 
 `java.util.UUID` can be used as parameter, in which case its string value is passed to statement.
 
+If the columns are not strictly defined (e.g. with types that can vary), the `SqlParser.folder` can be used to fold each row in a custom way.
+
+```scala
+import anorm.{ RowParser, SqlParser }
+
+val parser: RowParser[Map[String, Any]] = 
+  SqlParser.folder(Map.empty[String, Any]) { (map, value, meta) => 
+    Right(map + (meta.column.qualified -> value))
+  }
+
+val result: List[Map[String, Any]] = SQL"SELECT * FROM dyn_table".as(parser.*)
+```
+
 ### SQL queries using String Interpolation
 
 Since Scala 2.10 supports custom String Interpolation there is also a 1-step alternative to `SQL(queryString).on(params)` seen before. You can abbreviate the code as: 


### PR DESCRIPTION
Fix #43 

Integrates with the existing parser API:

```scala
val newKindOfRowParser = SqlParser.folder(initialValue)(...)

// Parses at least one row matching the custom folder parser
val resultSetParser = newKindOfRowParser.+
```