### PR TITLE
Single quotes in comments cause parse errors

### DIFF
--- a/core/src/test/scala/anorm/StatementParserSpec.scala
+++ b/core/src/test/scala/anorm/StatementParserSpec.scala
@@ -16,11 +16,11 @@ object StatementParserSpec extends org.specs2.mutable.Specification {
     "be parsed with 'name' and 'cat' parameters and support multiple lines" in {
       SqlStatementParser.parse("""
         SELECT * FROM schema.table
-        -- comment
+        -- Foo's comment
         WHERE (name = {name} AND category = {cat}) OR id = ?
       """) aka "updated statement and parameters" must beSuccessfulTry(
         TokenizedStatement(List(TokenGroup(List(StringToken("""SELECT * FROM schema.table
-        -- comment
+        -- Foo's comment
         WHERE (name = """)), Some("name")), TokenGroup(List(StringToken(" AND category = ")), Some("cat")), TokenGroup(List(StringToken(""") OR id = ?
       """)), None)), List("name", "cat")))
 
@@ -35,8 +35,8 @@ object StatementParserSpec extends org.specs2.mutable.Specification {
     "reserved '%' character must be preserved as special token" in {
       SqlStatementParser.parse(
         "SELECT * FROM Test WHERE id = {id} AND n LIKE '%strange%s fruit%s'").
-        aka("statement") must beSuccessfulTry(TokenizedStatement(
-          List(TokenGroup(List(StringToken("SELECT * FROM Test WHERE id = ")), Some("id")), TokenGroup(List(StringToken(" AND n LIKE "), StringToken("'"), PercentToken, StringToken("strange"), PercentToken, StringToken("s fruit"), PercentToken, StringToken("s"), StringToken("'")), None)), List("id")))
+        aka("statement") must beSuccessfulTry(TokenizedStatement(List(TokenGroup(List(StringToken("SELECT * FROM Test WHERE id = ")), Some("id")), TokenGroup(List(StringToken(" AND n LIKE '"), PercentToken, StringToken("strange"), PercentToken, StringToken("s fruit"), PercentToken, StringToken("s'")), None)), List("id")))
+
     }
   }
 


### PR DESCRIPTION
If we use a block comment that contains an apostrophe, we get a parse error.

```scala
SQL("select 1 /* foo's */")()
```

See the stack trace below -

```
java.lang.ArrayIndexOutOfBoundsException
  at java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:570)
  at java.lang.StringBuilder.append(StringBuilder.java:190)
  at org.postgresql.core.Parser.unmarkDoubleQuestion(Parser.java:223)
  at org.postgresql.core.v3.SimpleQuery.unmarkDoubleQuestion(SimpleQuery.java:124)
  at org.postgresql.core.v3.SimpleQuery.<init>(SimpleQuery.java:27)
  at org.postgresql.core.v3.QueryExecutorImpl.parseQuery(QueryExecutorImpl.java:199)
  at org.postgresql.core.v3.QueryExecutorImpl.createParameterizedQuery(QueryExecutorImpl.java:111)
  at org.postgresql.jdbc2.AbstractJdbc2Statement.<init>(AbstractJdbc2Statement.java:163)
  at org.postgresql.jdbc3.AbstractJdbc3Statement.<init>(AbstractJdbc3Statement.java:40)
  at org.postgresql.jdbc3g.AbstractJdbc3gStatement.<init>(AbstractJdbc3gStatement.java:27)
  at org.postgresql.jdbc4.AbstractJdbc4Statement.<init>(AbstractJdbc4Statement.java:34)
  at org.postgresql.jdbc4.Jdbc4Statement.<init>(Jdbc4Statement.java:28)
  at org.postgresql.jdbc4.Jdbc4PreparedStatement.<init>(Jdbc4PreparedStatement.java:21)
  at org.postgresql.jdbc4.Jdbc4PreparedStatement.<init>(Jdbc4PreparedStatement.java:16)
  at org.postgresql.jdbc4.Jdbc4Connection.prepareStatement(Jdbc4Connection.java:39)
  at org.postgresql.jdbc3.AbstractJdbc3Connection.prepareStatement(AbstractJdbc3Connection.java:276)
  at org.postgresql.jdbc2.AbstractJdbc2Connection.prepareStatement(AbstractJdbc2Connection.java:293)
  at com.zaxxer.hikari.proxy.ConnectionProxy.prepareStatement(ConnectionProxy.java:263)
  at com.zaxxer.hikari.proxy.ConnectionJavassistProxy.prepareStatement(ConnectionJavassistProxy.java)
  at anorm.SimpleSql.getFilledStatement(SimpleSql.scala:59)
  at anorm.SimpleSql$$anonfun$preparedStatement$1.apply(SimpleSql.scala:70)
  at anorm.SimpleSql$$anonfun$preparedStatement$1.apply(SimpleSql.scala:70)
  at resource.DefaultManagedResource.open(AbstractManagedResource.scala:106)
  at resource.AbstractManagedResource.acquireFor(AbstractManagedResource.scala:85)
  at resource.ManagedResourceOperations$$anon$2.acquireFor(ManagedResourceOperations.scala:40)
  at resource.DeferredExtractableManagedResource.acquireFor(AbstractManagedResource.scala:27)
  at resource.ManagedResourceOperations$class.acquireAndGet(ManagedResourceOperations.scala:25)
  at resource.DeferredExtractableManagedResource.acquireAndGet(AbstractManagedResource.scala:24)
  at anorm.WithResult$class.apply(SqlResult.scala:55)
  at anorm.SimpleSql.apply(SimpleSql.scala:6)
```