### PR TITLE
Short and bytes can be parsed as Int, Long or BigInteger

### DIFF
--- a/Highlights25.md
+++ b/Highlights25.md
@@ -3,3 +3,4 @@
 This page highlights the new features of Anorm 2.5. If you want learn about the changes you need to make to migrate to Anorm 2.5, check out the [[Migration Guide|Migration25]].
 
 - Row parser automatically generated for case classes: `Macro.namedParser[T]`, `Macro.indexedParser[T]` and `Macro.parser[T](names)`.
+- New conversions for `Short` and `Byte` columns, to parsed them as `Int`, `Long` or `BigInt`.

--- a/Migration25.md
+++ b/Migration25.md
@@ -30,6 +30,25 @@ val anyVal: Any = myVal
 SQL"UPDATE t SET v = ${anorm.Object(anyVal)}"
 ```
 
+## Type mappings
+
+More conversions are available.
+
+**Numeric types**
+
+Column conversions for numeric types have been improved.
+
+There are new conversions extending column support.
+
+Column (JDBC type) | (as) JVM/Scala type
+-------------------|---------------------
+Short              | BigInteger
+Short              | Long
+Short              | Int
+Byte               | BigInteger
+Byte               | Long
+Byte               | Int
+
 ## Joda
 
 [Joda](http://www.joda.org) `LocalDateTime` and `LocalDate` are supported as parameter, passed as `Timestamp`. The following JDBC column types can also be parsed as `LocalDateTime` or `LocalDate`: `Date`, `Long`, `Timestamp` or *Wrapper* (any type providing `.getTimestamp`).

--- a/core/src/main/scala/anorm/Column.scala
+++ b/core/src/main/scala/anorm/Column.scala
@@ -108,6 +108,8 @@ object Column extends JodaColumn with JavaTimeColumn {
       case bd: JBigDec => Right(bd.intValue)
       case l: Long => Right(l.toInt)
       case i: Int => Right(i)
+      case s: Short => Right(s.toInt)
+      case b: Byte => Right(b.toInt)
       case bool: Boolean => Right(if (!bool) 0 else 1)
       case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${value.asInstanceOf[AnyRef].getClass} to Int for column $qualified"))
     }
@@ -197,6 +199,8 @@ object Column extends JodaColumn with JavaTimeColumn {
       case bd: JBigDec => Right(bd.longValue)
       case int: Int => Right(int: Long)
       case long: Long => Right(long)
+      case s: Short => Right(s.toLong)
+      case b: Byte => Right(b.toLong)
       case bool: Boolean => Right(if (!bool) 0l else 1l)
       case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${value.asInstanceOf[AnyRef].getClass} to Long for column $qualified"))
     }
@@ -210,6 +214,8 @@ object Column extends JodaColumn with JavaTimeColumn {
       case bd: JBigDec => Right(bd.toBigInteger)
       case long: Long => Right(BigInteger.valueOf(long))
       case int: Int => Right(BigInteger.valueOf(int))
+      case s: Short => Right(BigInteger.valueOf(s))
+      case b: Byte => Right(BigInteger.valueOf(b))
       case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${value.asInstanceOf[AnyRef].getClass} to BigInteger for column $qualified"))
     }
   }

--- a/core/src/test/scala/anorm/ColumnSpec.scala
+++ b/core/src/test/scala/anorm/ColumnSpec.scala
@@ -156,6 +156,18 @@ object ColumnSpec
       SQL("SELECT i").as(scalar[Long].single) aka "parsed long" must_== 4l
     }
 
+    "be parsed from short" in withQueryResult(shortList :+ 3.toShort) {
+      implicit con =>
+        SQL("SELECT s").as(scalar[Long].single).
+          aka("parsed short") must_== 3L
+    }
+
+    "be parsed from byte" in withQueryResult(byteList :+ 4.toByte) {
+      implicit con =>
+        SQL("SELECT b").as(scalar[Long].single).
+          aka("parsed byte") must_== 4L
+    }
+
     "be parsed from false as 0" in withQueryResult(booleanList :+ false) {
       implicit con =>
         SQL("SELECT b").as(scalar[Short].single) aka "parsed short" must_== 0l
@@ -192,6 +204,18 @@ object ColumnSpec
 
     "be parsed from integer" in withQueryResult(intList :+ 4) { implicit con =>
       SQL("SELECT i").as(scalar[Int].single) aka "parsed integer" must_== 4
+    }
+
+    "be parsed from short" in withQueryResult(shortList :+ 3.toShort) {
+      implicit con =>
+        SQL("SELECT s").as(scalar[Int].single).
+          aka("parsed short") must_== 3
+    }
+
+    "be parsed from byte" in withQueryResult(byteList :+ 4.toByte) {
+      implicit con =>
+        SQL("SELECT b").as(scalar[Int].single).
+          aka("parsed byte") must_== 4
     }
 
     "be parsed from false as 0" in withQueryResult(booleanList :+ false) {
@@ -408,7 +432,6 @@ object ColumnSpec
       implicit con =>
         SQL("SELECT s").as(scalar[java.math.BigDecimal].single).
           aka("parsed big decimal") must_== java.math.BigDecimal.valueOf(7)
-
     }
 
     "be parsed from byte" in withQueryResult(byteList :+ 8.toByte) {
@@ -486,6 +509,18 @@ object ColumnSpec
           aka("parsed int") must_== java.math.BigInteger.valueOf(2)
 
     }
+
+    "be parsed from short" in withQueryResult(shortList :+ 3.toShort) {
+      implicit con =>
+        SQL("SELECT bi").as(scalar[java.math.BigInteger].single).
+          aka("parsed short") must_== java.math.BigInteger.valueOf(3)
+    }
+
+    "be parsed from byte" in withQueryResult(byteList :+ 4.toByte) {
+      implicit con =>
+        SQL("SELECT bi").as(scalar[java.math.BigInteger].single).
+          aka("parsed byte") must_== java.math.BigInteger.valueOf(4)
+    }
   }
 
   "Column mapped as Scala big integer" should {
@@ -517,6 +552,18 @@ object ColumnSpec
         SQL("SELECT bi").as(scalar[BigInt].single).
           aka("parsed int") must_== BigInt(2)
 
+    }
+
+    "be parsed from short" in withQueryResult(shortList :+ 3.toShort) {
+      implicit con =>
+        SQL("SELECT bi").as(scalar[BigInt].single).
+          aka("parsed short") must_== BigInt(3)
+    }
+
+    "be parsed from byte" in withQueryResult(byteList :+ 4.toByte) {
+      implicit con =>
+        SQL("SELECT bi").as(scalar[BigInt].single).
+          aka("parsed byte") must_== BigInt(4)
     }
   }
 

--- a/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
+++ b/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
@@ -827,12 +827,12 @@ Following table describes which JDBC numeric types (getters on `java.sql.ResultS
 BigDecimal<sup>1</sup> | Yes                    | Yes                    | No      | No   | Yes    | No    | Yes | Yes  | No
 BigInteger<sup>2</sup> | Yes                    | Yes                    | No      | No   | Yes    | Yes   | Yes | Yes  | No
 Boolean                | No                     | No                     | Yes     | Yes  | No     | No    | Yes | Yes  | Yes
-Byte                   | Yes                    | No                     | No      | Yes  | Yes    | Yes   | No  | No   | Yes
+Byte                   | Yes                    | Yes                    | No      | Yes  | Yes    | Yes   | Yes | Yes  | Yes
 Double                 | Yes                    | No                     | No      | No   | Yes    | No    | No  | No   | No
 Float                  | Yes                    | No                     | No      | No   | Yes    | Yes   | No  | No   | No
 Int                    | Yes                    | Yes                    | No      | No   | Yes    | Yes   | Yes | Yes  | No
 Long                   | Yes                    | Yes                    | No      | No   | No     | No    | Yes | Yes  | No
-Short                  | Yes                    | No                     | No      | Yes  | Yes    | Yes   | No  | No   | Yes
+Short                  | Yes                    | Yes                    | No      | Yes  | Yes    | Yes   | Yes | Yes  | Yes
 
 - 1. Types `java.math.BigDecimal` and `scala.math.BigDecimal`.
 - 2. Types `java.math.BigInteger` and `scala.math.BigInt`.


### PR DESCRIPTION
Fix #46

A column returned as a Short or a Byte can be parsed to an Int, a long or a BigInteger (both java and scala version)