### PR TITLE
Wrong exception handling in SqlRequestError as of Anorm 2.4.0?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: scala
 jdk:
   - oraclejdk8
+before_script:
+- mkdir -p $HOME/.sbt/launchers/0.13.8/
+- curl -L -o $HOME/.sbt/launchers/0.13.8/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.8/sbt-launch.jar
 script:
   - sbt +test docs/test

--- a/core/src/main/scala/anorm/Anorm.scala
+++ b/core/src/main/scala/anorm/Anorm.scala
@@ -12,39 +12,6 @@ import scala.util.Failure
 
 import resource.{ managed, ManagedResource }
 
-/** Error from processing SQL */
-sealed trait SqlRequestError {
-  def message: String
-
-  /** Returns error as a failure. */
-  def toFailure = Failure(sys.error(message))
-}
-
-case class ColumnNotFound(
-    column: String, possibilities: List[String]) extends SqlRequestError {
-
-  lazy val message = s"$column not found, available columns : " +
-    possibilities.map(_.dropWhile(_ == '.')).mkString(", ")
-
-  override lazy val toString = message
-}
-
-object ColumnNotFound {
-  def apply(column: String, row: Row): ColumnNotFound =
-    ColumnNotFound(column, row.metaData.availableColumns)
-}
-
-case class UnexpectedNullableFound(message: String) extends SqlRequestError
-case class SqlMappingError(reason: String) extends SqlRequestError {
-  lazy val message = s"SqlMappingError($reason)"
-  override lazy val toString = message
-}
-
-case class TypeDoesNotMatch(reason: String) extends SqlRequestError {
-  lazy val message = s"TypeDoesNotMatch($reason)"
-  override lazy val toString = message
-}
-
 /**
  * Untyped value wrapper.
  *

--- a/core/src/main/scala/anorm/SqlRequestError.scala
+++ b/core/src/main/scala/anorm/SqlRequestError.scala
@@ -1,0 +1,49 @@
+package anorm
+
+import scala.util.Failure
+
+/** Anorm runtime exception */
+final case class AnormException(message: String)
+    extends Exception with scala.util.control.NoStackTrace {
+  override def getMessage() = message
+}
+
+/** Error from processing SQL */
+sealed trait SqlRequestError {
+  def message: String
+
+  /** Returns error as a failure. */
+  def toFailure = Failure(AnormException(message))
+}
+
+/**
+ * Error raised when the specified `column` cannot be found in results.
+ *
+ * @param column the name of the not found column
+ * @param possibilities the names of the available columns
+ */
+case class ColumnNotFound(
+    column: String, possibilities: List[String]) extends SqlRequestError {
+
+  lazy val message = s"'$column' not found, available columns: " +
+    possibilities.map(_.dropWhile(_ == '.')).mkString(", ")
+
+  override lazy val toString = message
+}
+
+object ColumnNotFound {
+  def apply(column: String, row: Row): ColumnNotFound =
+    ColumnNotFound(column, row.metaData.availableColumns)
+}
+
+case class UnexpectedNullableFound(message: String) extends SqlRequestError
+
+case class SqlMappingError(reason: String) extends SqlRequestError {
+  lazy val message = s"SqlMappingError($reason)"
+  override lazy val toString = message
+}
+
+case class TypeDoesNotMatch(reason: String) extends SqlRequestError {
+  lazy val message = s"TypeDoesNotMatch($reason)"
+  override lazy val toString = message
+}

--- a/core/src/test/scala/anorm/SqlRequestErrorSpec.scala
+++ b/core/src/test/scala/anorm/SqlRequestErrorSpec.scala
@@ -1,0 +1,33 @@
+package anorm
+
+object SqlRequestErrorSpec extends org.specs2.mutable.Specification {
+  "SQL request error" title
+
+  "ColumnNotFound" should {
+    "be converted to Failure" in {
+      ColumnNotFound("foo", List("bar")).toFailure must beFailedTry.
+        withThrowable[AnormException]("'foo' not found, available columns: bar")
+    }
+  }
+
+  "UnexpectedNullableFound" should {
+    "be converted to Failure" in {
+      UnexpectedNullableFound("Foo message").toFailure must beFailedTry.
+        withThrowable[AnormException]("Foo message")
+    }
+  }
+
+  "SqlMappingError" should {
+    "be converted to Failure" in {
+      SqlMappingError("Foo").toFailure must beFailedTry.
+        withThrowable[AnormException]("SqlMappingError\\(Foo\\)")
+    }
+  }
+
+  "TypeDoesNotMatch" should {
+    "be converted to Failure" in {
+      TypeDoesNotMatch("Foo").toFailure must beFailedTry.
+        withThrowable[AnormException]("TypeDoesNotMatch\\(Foo\\)")
+    }
+  }
+}

--- a/core/src/test/scala/anorm/SqlResultSpec.scala
+++ b/core/src/test/scala/anorm/SqlResultSpec.scala
@@ -17,7 +17,7 @@ object SqlResultSpec extends org.specs2.mutable.Specification with H2Database {
         } yield (a -> b)
 
         SQL("SELECT * FROM test") as parser.single must throwA[Exception](
-          message = "col1 not found")
+          message = "'col1' not found")
       }
     }
 
@@ -45,7 +45,7 @@ object SqlResultSpec extends org.specs2.mutable.Specification with H2Database {
         } yield Tuple3(a, bc._1, bc._2)
 
         SQL("SELECT * FROM test") as parser.single must throwA[Exception](
-          message = "col1 not found")
+          message = "'col1' not found")
       }
     }
 
@@ -62,7 +62,7 @@ object SqlResultSpec extends org.specs2.mutable.Specification with H2Database {
         } yield Tuple3(a, bc._1, bc._2)
 
         SQL("SELECT * FROM test") as parser.single must throwA[Exception](
-          message = "col2 not found")
+          message = "'col2' not found")
       }
 
     "return None from optional sub-parser" in withQueryResult(


### PR DESCRIPTION
In Anorm 2.4.0, file anorm/Anorm.scala, lines 19 and 20 it reads:

    /** Returns error as a failure. */
    def toFailure = Failure(sys.error(message))

In Scala 2.11.7, file scala/sys/package.scala, line 27 it reads:

    def error(message: String): Nothing = throw new RuntimeException(message)

Mind the `throw` keyword! Next, in Scala 2.11.7, file scala/Try.scala, line 198 it reads:

    final case class Failure[+T](exception: Throwable) extends Try[T] {

This leads me to the conclusion that a `Failure` object is never returned, but a `RuntimeException` is thrown instead each time execution hits the initial `toFailure` method/function.

I guess this explains why I don't get a reasonable error message sometimes, for example if I forget to provide a parameter to an `SqlQuery`:

    SQL("SELECT content FROM documents WHERE isbn = {isbn}") as myParser.single

Here I forgot to provide the `{isbn}` parameter.

BTW: Wouldn't it be better to use an `SQLException` instead anyway? This would describe the problem domain much better than a generic `RuntimeException`.