### PR TITLE
Stream query results with an enumerator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: scala
 jdk:
   - oraclejdk8
+before_script:
+- mkdir -p $HOME/.sbt/launchers/0.13.8/
+- curl -L -o $HOME/.sbt/launchers/0.13.8/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.8/sbt-launch.jar
 script:
   - sbt +test docs/test

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val anorm = project
     }) ++ Seq(
       "specs2-core",
       "specs2-junit"
-    ).map("org.specs2" %% _ % "2.4.9" % Test)
+    ).map("org.specs2" %% _ % "2.4.9" % Test) ++ Seq(
+      "com.typesafe.play" %% "play-iteratees" % "2.4.0" % Test)
   }).dependsOn(`anorm-tokenizer`)
 
 lazy val `anorm-parent` = (project in file("."))

--- a/core/src/test/scala/anorm/PlaySpec.scala
+++ b/core/src/test/scala/anorm/PlaySpec.scala
@@ -1,0 +1,48 @@
+import scala.util.{ Failure, Success }
+import scala.concurrent.Future
+
+import play.api.libs.iteratee.{ Concurrent, Enumerator, Input, Iteratee }
+
+import anorm.{ SqlParser, _ }
+
+import acolyte.jdbc.AcolyteDSL.withQueryResult
+import acolyte.jdbc.RowLists.stringList
+import acolyte.jdbc.Implicits._
+
+// TODO: Move in a separate module
+object PlaySpec extends org.specs2.mutable.Specification {
+  "Play integration" title
+
+  "Iteratees" should {
+    "broadcast the streaming result" in {
+      val rowParser = SqlParser.scalar[String]
+      val (resultEnum, chan): (Enumerator[String], Concurrent.Channel[String]) =
+        Concurrent.broadcast[String]
+      val futureRes: Future[List[String]] =
+        resultEnum.run(Iteratee.getChunks[String])
+
+      @annotation.tailrec
+      def pushToChannel(cursor: Option[Cursor]): Unit = cursor match {
+        case Some(cursor) => cursor.row.as(rowParser) match {
+          case Success(elem) => {
+            chan.push(elem)
+            pushToChannel(cursor.next)
+          }
+          case Failure(err) => chan.end(err)
+        }
+        case _ => chan.eofAndEnd()
+      }
+
+      Future {
+        Thread.sleep(500)
+        withQueryResult(stringList :+ "A" :+ "B" :+ "C") { implicit c =>
+          SQL"SELECT * FROM Test".withResult(pushToChannel)
+        }
+      }
+
+      chan.push("_") // before the async data from result      
+
+      futureRes must beEqualTo(List("_", "A", "B", "C")).await(1000)
+    }
+  }
+}


### PR DESCRIPTION
Hi

I'm trying to migrate from anorm v2.3.9 to v2.4.0 but I'm facing some difficulties when streaming results from an SQL query with an Enumerator.

In 2.3.9, I had this :
```scala
implicit val connection = DB.getConnection()

val query = SQL("select * from table")
val stream: Stream[Row] = query()
val enumerator: Enumerator[Row] = Enumerator.enumerate(stream).onDoneEnumerating(connection.close())
```

Now the method `apply` is deprecated in favor of `fold`, `foldWhile` or `withResult`.

So I tried this :
```scala
implicit val connection = DB.getConnection()

val query = SQL("select * from table")
val enumerator: Enumerator[Row] = query.withResult { c =>
  Enumerator.unfold(c) {
    case Some(cursor) => Some(cursor.next, cursor.row)
    case None => None
  }
}.onDoneEnumerating(connection.close())
```

But I get this error :
```
[ERROR] [07/20/2015 17:58:23.986] [application-akka.actor.default-dispatcher-4] [akka.dispatch.Dispatcher] The object is already closed [90007-187]
org.h2.jdbc.JdbcSQLException: The object is already closed [90007-187]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:345)
	at org.h2.message.DbException.get(DbException.java:179)
	at org.h2.message.DbException.get(DbException.java:155)
	at org.h2.message.DbException.get(DbException.java:144)
	at org.h2.jdbc.JdbcResultSet.checkClosed(JdbcResultSet.java:3174)
	at org.h2.jdbc.JdbcResultSet.next(JdbcResultSet.java:121)
	at com.zaxxer.hikari.proxy.ResultSetJavassistProxy.next(ResultSetJavassistProxy.java)
	at anorm.Cursor$.anorm$Cursor$$apply(Cursor.scala:52)
	at anorm.Cursor$$anon$1.next(Cursor.scala:31)
```

I'm guessing that the connection is closed before the call to `cursor.next` but I don't see how to fix this.