### PR TITLE
Referencing the same table twice causes aliased columns to be read incorrectly.

### DIFF
--- a/core/src/main/scala/anorm/Anorm.scala
+++ b/core/src/main/scala/anorm/Anorm.scala
@@ -38,8 +38,8 @@ private[anorm] case class MetaData(ms: List[MetaDataItem]) {
   /** Returns meta data for specified column. */
   def get(columnName: String): Option[MetaDataItem] = {
     val key = columnName.toUpperCase
-    dictionary2.get(key).orElse(dictionary.get(key)).
-      orElse(aliasedDictionary.get(key))
+    aliasedDictionary.get(key).
+      orElse(dictionary2 get key).orElse(dictionary get key)
   }
 
   private lazy val dictionary: Map[String, MetaDataItem] =
@@ -51,11 +51,10 @@ private[anorm] case class MetaData(ms: List[MetaDataItem]) {
       column.toUpperCase() -> m
     }).toMap
 
-  private lazy val aliasedDictionary: Map[String, MetaDataItem] = {
-    ms.flatMap(m => {
+  private lazy val aliasedDictionary: Map[String, MetaDataItem] =
+    ms.flatMap(m =>
       m.column.alias.map(a => Map(a.toUpperCase() -> m)).getOrElse(Map.empty)
-    }).toMap
-  }
+    ).toMap
 
   lazy val columnCount = ms.size
 

--- a/core/src/main/scala/anorm/Row.scala
+++ b/core/src/main/scala/anorm/Row.scala
@@ -125,9 +125,9 @@ trait Row {
    */
   private[anorm] def get(a: String): MayErr[SqlRequestError, (Any, MetaDataItem)] = for {
     m <- MayErr(metaData.get(a).toRight(ColumnNotFound(a, this)))
-    data <- MayErr(columnsDictionary.get(m.column.qualified.toUpperCase()).
+    data <- MayErr(m.column.alias.flatMap(aliasesDictionary.get(_)).
+      orElse(columnsDictionary.get(m.column.qualified.toUpperCase())).
       toRight(ColumnNotFound(m.column.qualified, metaData.availableColumns)))
-
   } yield (data, m)
 
   /** Try to get data matching index. */

--- a/core/src/test/scala/anorm/MetaDataSpec.scala
+++ b/core/src/test/scala/anorm/MetaDataSpec.scala
@@ -1,0 +1,24 @@
+package anorm
+
+object MetaDataSpec extends org.specs2.mutable.Specification {
+  "Meta-data" title
+
+  "Meta-data" should {
+    val item1 = MetaDataItem(ColumnName(
+      "TEST1.FOO", Some("ALI")), true, "java.lang.String")
+
+    val item2 = MetaDataItem(ColumnName(
+      "TEST1.FOO", Some("FOO")), true, "java.lang.String")
+
+    val item3 = MetaDataItem(ColumnName(
+      "TEST1.FOO", Some("IAS")), true, "java.lang.String")
+
+    val meta = MetaData(List(item1, item2, item3))
+
+    "be support colum aliases" in {
+      meta.get("ALI") aka "ALI" must beSome(item1) and (
+        meta.get("FOO") aka "FOO" must beSome(item2)) and (
+          meta.get("IAS") aka "IAS" must beSome(item3))
+    }
+  }
+}


### PR DESCRIPTION
Stackoverflow Question:
http://stackoverflow.com/questions/32062304/mysql-aliased-tables-in-anorm-are-not-recognized

working demo:
https://github.com/narayanjr/anorm_test

If you reference the same table twice in a query, then alias the same columns on those two tables with unique names, the value of the first aliased term (first referenced in mysql) are replaced by the values of the last aliased term.