### PR TITLE
Pattern matching for Cursor

### DIFF
--- a/core/src/main/scala/anorm/Cursor.scala
+++ b/core/src/main/scala/anorm/Cursor.scala
@@ -9,6 +9,8 @@ sealed trait Cursor {
 
   /** Cursor to next row */
   def next: Option[Cursor]
+
+  override lazy val toString = s"Cursor($row)"
 }
 
 /** Cursor companion */
@@ -28,8 +30,11 @@ object Cursor {
       val columns: List[Int] = List.range(1, meta.columnCount + 1)
       val row = ResultRow(meta, columns.map(rs.getObject(_)))
 
-      def next = apply(rs, meta, columns)
+      lazy val next = apply(rs, meta, columns)
     })
+
+  def unapply(cursor: Cursor): Option[(Row, Option[Cursor])] =
+    Some(cursor.row -> cursor.next)
 
   /**
    * Returns a cursor for a result set initialized on the first row.

--- a/core/src/test/scala/anorm/CursorSpec.scala
+++ b/core/src/test/scala/anorm/CursorSpec.scala
@@ -32,6 +32,15 @@ object CursorSpec extends org.specs2.mutable.Specification {
             })
         }
     }
+
+    "match pattern" in {
+      Cursor(stringList :+ "Foo" :+ "Bar" resultSet) must beSome[Cursor].like {
+        case Cursor(row1, b) => row1[String](1) must_== "Foo" and (
+          b must beSome[Cursor].like {
+            case Cursor(row2, None) => row2[String](1) must_== "Bar"
+          })
+      }
+    }
   }
 
   def stringList = rowList1(classOf[String] -> "str")


### PR DESCRIPTION
Implicit unapply for the `Cursor` trait