### PR TITLE
Cursor for streaming but unable to set fetch size

### DIFF
--- a/core/src/main/scala/anorm/Anorm.scala
+++ b/core/src/main/scala/anorm/Anorm.scala
@@ -207,9 +207,7 @@ object Sql { // TODO: Rename to SQL
   private[anorm] def withResult[T](res: ManagedResource[ResultSet], onFirstRow: Boolean)(op: Option[Cursor] => T): ManagedResource[T] =
     res.map(rs => op(if (onFirstRow) Cursor.onFirstRow(rs) else Cursor(rs)))
 
-  private[anorm] def asTry[T](parser: ResultSetParser[T], rs: ManagedResource[ResultSet], onFirstRow: Boolean)(implicit connection: Connection): Try[T] =
-    Try(withResult(rs, onFirstRow)(parser) acquireAndGet identity).
-      flatMap(_.fold[Try[T]](_.toFailure, TrySuccess.apply))
+  private[anorm] def asTry[T](parser: ResultSetParser[T], rs: ManagedResource[ResultSet], onFirstRow: Boolean)(implicit connection: Connection): Try[T] = Try(withResult(rs, onFirstRow)(parser) acquireAndGet identity).flatMap(_.fold[Try[T]](_.toFailure, TrySuccess.apply))
 
   @annotation.tailrec
   private[anorm] def zipParams(ns: Seq[String], vs: Seq[ParameterValue], ps: Map[String, ParameterValue]): Map[String, ParameterValue] = (ns.headOption, vs.headOption) match {

--- a/core/src/main/scala/anorm/SimpleSql.scala
+++ b/core/src/main/scala/anorm/SimpleSql.scala
@@ -43,9 +43,10 @@ case class SimpleSql[T](sql: SqlQuery, params: Map[String, ParameterValue], defa
 
       val stmt = if (getGeneratedKeys) connection.prepareStatement(psql, java.sql.Statement.RETURN_GENERATED_KEYS) else connection.prepareStatement(psql)
 
+      sql.fetchSize.foreach(stmt.setFetchSize(_))
       sql.timeout.foreach(stmt.setQueryTimeout(_))
 
-      vs foreach { case (i, v) => v.set(stmt, i + 1) }
+      vs.foreach { case (i, v) => v.set(stmt, i + 1) }
 
       stmt
     }
@@ -74,4 +75,15 @@ case class SimpleSql[T](sql: SqlQuery, params: Map[String, ParameterValue], defa
   /** Returns a copy with updated flag. */
   def withResultSetOnFirstRow(onFirst: Boolean): SimpleSql[T] =
     copy(resultSetOnFirstRow = onFirst)
+
+  /** Fetch size */
+  def fetchSize: Option[Int] = sql.fetchSize
+
+  /**
+   * Returns this query with the fetch suze updated to the row `count`.
+   * @see [[SqlQuery.fetchSize]]
+   */
+  def withFetchSize(count: Option[Int]): SimpleSql[T] =
+    copy(sql.withFetchSize(count))
+
 }

--- a/core/src/main/scala/anorm/SqlQuery.scala
+++ b/core/src/main/scala/anorm/SqlQuery.scala
@@ -28,9 +28,16 @@ sealed trait SqlQuery {
   /** Execution timeout */
   def timeout: Option[Int]
 
-  /** Returns this query with timeout updated to `seconds` delay. */
+  /** Returns this query with the timeout updated to `seconds` delay. */
   def withQueryTimeout(seconds: Option[Int]): SqlQuery =
-    SqlQuery.prepare(stmt, paramsInitialOrder, seconds)
+    SqlQuery.prepare(stmt, paramsInitialOrder, seconds, fetchSize)
+
+  /** Fetch size */
+  def fetchSize: Option[Int]
+
+  /** Returns this query with the fetch suze updated to the row `count`. */
+  def withFetchSize(count: Option[Int]): SqlQuery =
+    SqlQuery.prepare(stmt, paramsInitialOrder, timeout, count)
 
   private[anorm] def asSimple: SimpleSql[Row] = asSimple(defaultParser)
 
@@ -49,7 +56,7 @@ sealed trait SqlQuery {
 
   private def defaultParser: RowParser[Row] = RowParser(Success(_))
 
-  private[anorm] def copy(statement: TokenizedStatement = this.stmt, paramsInitialOrder: List[String] = this.paramsInitialOrder, timeout: Option[Int] = this.timeout) = SqlQuery.prepare(statement, paramsInitialOrder, timeout)
+  private[anorm] def copy(statement: TokenizedStatement = this.stmt, paramsInitialOrder: List[String] = this.paramsInitialOrder, timeout: Option[Int] = this.timeout, fetchSize: Option[Int] = this.fetchSize) = SqlQuery.prepare(statement, paramsInitialOrder, timeout, fetchSize)
 
 }
 
@@ -64,10 +71,11 @@ object SqlQuery {
    * @param params Parameter names in initial order (see [[SqlQuery.paramsInitialOrder]])
    * @param tmout Query execution timeout (see [[SqlQuery.timeout]])
    */
-  private[anorm] def prepare(st: TokenizedStatement, params: List[String] = List.empty, tmout: Option[Int] = None): SqlQuery = new SqlQuery {
+  private[anorm] def prepare(st: TokenizedStatement, params: List[String] = List.empty, tmout: Option[Int] = None, fetchSz: Option[Int] = None): SqlQuery = new SqlQuery {
     val stmt = st
     val paramsInitialOrder = params
     val timeout = tmout
+    val fetchSize = fetchSz
   }
 
   /** Extractor for pattern matching */

--- a/core/src/test/scala/anorm/AnormSpec.scala
+++ b/core/src/test/scala/anorm/AnormSpec.scala
@@ -60,8 +60,8 @@ object AnormSpec extends Specification with H2Database with AnormTest {
 
       "return None for missing optional value" in withQueryResult(
         null.asInstanceOf[String]) { implicit c =>
-          SQL("SELECT * FROM test").as(scalar[String].singleOpt).
-            aka("single value") must beNone
+          SQL"SELECT * FROM test".withFetchSize(Some(1)).
+            as(scalar[String].singleOpt) must beNone
         }
 
       "return 0 for missing optional numeric" in withQueryResult(


### PR DESCRIPTION
Because `setFetchSize` is a member of `java.sql.Statement` there's no opportunity to actually set the fetch size prior to invoking `Sql#withResult`. This causes `withResult` cursors to not use server-side cursors at all for certain drivers (specifically PostgreSQL, Redshift, and Oracle).