### PR TITLE
Macro indexedParser add a way to specify a Prefix

### DIFF
--- a/core/src/test/scala/anorm/MacroSpec.scala
+++ b/core/src/test/scala/anorm/MacroSpec.scala
@@ -68,9 +68,44 @@ object MacroSpec extends org.specs2.mutable.Specification {
       }
   }
 
+  "Generated indexed parser (with an offset)" should {
+    // No Column[Bar] so compilation error is expected
+    shapeless.test.illTyped("anorm.Macro.offsetParser[Foo[Bar]]")
+
+    "be successful for Bar" in withQueryResult(
+      RowLists.intList :+ 1 :+ 3) { implicit c =>
+        SQL"TEST".as(Macro.offsetParser[Bar](0).*) must_== List(Bar(1), Bar(3))
+      }
+
+    "be successful for Foo[Int]" in withQueryResult(
+      fooRow :+ (1.2F, "str1", 1, 2L, true) :+ (
+        2.3F, "str2", 4, null.asInstanceOf[Long],
+        null.asInstanceOf[Boolean]) :+ (3.4F, "str3", 5, 3L,
+          null.asInstanceOf[Boolean]) :+ (5.6F, "str4", 6,
+            null.asInstanceOf[Long], false)) { implicit con =>
+        val parser: RowParser[Foo[Int]] = Macro.offsetParser[Foo[Int]](0)
+
+        SQL"TEST".as(parser.*) must_== List(Foo(1.2F, "str1")(1, Some(2L))(Some(true)), Foo(2.3F, "str2")(4, None)(None), Foo(3.4F, "str3")(5, Some(3L))(None), Foo(5.6F, "str4")(6, None)(Some(false)))
+      }
+
+    "be successful for Goo[T] with offset = 2" in withQueryResult(
+      fooRow :+ (1.2F, "str1", 1, 2L, true) :+ (
+        2.3F, "str2", 4, null.asInstanceOf[Long],
+        null.asInstanceOf[Boolean]) :+ (3.4F, "str3", 5, 3L,
+          null.asInstanceOf[Boolean]) :+ (5.6F, "str4", 6,
+            null.asInstanceOf[Long], false)) { implicit con =>
+        val parser: RowParser[Goo[Int]] = Macro.offsetParser[Goo[Int]](2)
+
+        SQL"TEST".as(parser.*) must_== List(Goo(1, Some(2L), Some(true)), Goo(4, None, None), Goo(5, Some(3L), None), Goo(6, None, Some(false)))
+      }
+  }
+
   case class Bar(v: Int)
   case class Foo[T](r: Float, bar: String = "Default")(
       lorem: T, opt: Option[Long] = None)(x: Option[Boolean]) {
     override lazy val toString = s"Foo($r, $bar)($lorem, $opt)($x)"
+  }
+  case class Goo[T](lorem: T, opt: Option[Long], x: Option[Boolean]) {
+    override lazy val toString = s"Goo($lorem, $opt, $x)"
   }
 }

--- a/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
+++ b/docs/manual/working/scalaGuide/main/sql/ScalaAnorm.md
@@ -255,21 +255,31 @@ get[String]("name") ~ get[Option[Int]]("year") map {
 val result: List[Info] = SQL"SELECT * FROM list".as(parser.*)
 ```
 
-A similar macro `indexedParser[T]` is available to get column values by positions instead of names.
+The similar macros `indexedParser[T]` and `offsetParser[T]` are available to get column values by positions instead of names.
 
 ```scala
 import anorm.{ Macro, RowParser }
 
 case class Info(name: String, year: Option[Int])
 
-val parser: RowParser[Info] = Macro.indexedParser[Info]
+val parser1: RowParser[Info] = Macro.indexedParser[Info]
 /* Generated as:
 get[String](1) ~ get[Option[Int]](2) map {
   case name ~ year => Info(name, year)
 }
 */
 
-val result: List[Info] = SQL"SELECT * FROM list".as(parser.*)
+val result1: List[Info] = SQL"SELECT * FROM list".as(parser1.*)
+
+// With offset
+val parser2: RowParser[Info] = Macro.offsetParser[Info](2)
+/* Generated as:
+get[String](2 + 1) ~ get[Option[Int]](2 + 2) map {
+  case name ~ year => Info(name, year)
+}
+*/
+
+val result2: List[Info] = SQL"SELECT * FROM list".as(parser2.*)
 ```
 
 To indicate custom names for the columns to be parsed, the macro `parser[T](names)` can be used.


### PR DESCRIPTION
Hello, currently It's really hard to use a Indexed Parser with a join,

currently it would be really useful if there is a way to specify an optional prefix, like when creating the parser we could have something like that:

val parser: RowParser[Demo] = Macro.indexedParser[Demo](4)

Which would result that the index inside the parser adds +4 

i.e.:
```
parserImpl[T](c) { (t, _, i) => q"anorm.SqlParser.get[$t](${i + 1})" }
```

would be:
```
parserImpl[T](c) { (t, _, i) => q"anorm.SqlParser.get[$t](${i + 1 + index})" }
```

