### PR TITLE
Column aliaser

### DIFF
--- a/Highlights26.md
+++ b/Highlights26.md
@@ -4,4 +4,5 @@ This page highlights the new features of Anorm 2.6. If you want learn about the 
 
 - Iteratees module
 - The new operation `.executeInsert1` allows to select columns among the generated keys.
-- New macro `offsetParser[T](offset: Int)`
+- New macro `offsetParser[T](offset: Int)`.
+- The `ColumnAliaser` to define user aliases over the results, before parsing.

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,13 @@
 import AnormGeneration.{ generateFunctionAdapter => GFA }
 import Common._
+import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.plugin.MimaKeys.{
   binaryIssueFilters, previousArtifacts
 }
 
 val PlayVersion = playVersion(sys.props.getOrElse("play.version", "2.5.0-M1"))
 
-lazy val acolyteVersion = "1.0.33-j7p"
+lazy val acolyteVersion = "1.0.35-j7p"
 
 lazy val `anorm-tokenizer` = project
   .in(file("tokenizer"))
@@ -36,9 +37,18 @@ lazy val anorm = project
       missMeth("anorm.SqlQuery.copy"/* private */),
       missMeth("anorm.SqlQuery.copy$default$4"/* private */),
       missMeth("anorm.Sql.getFilledStatement"/* deprecated 2.3.6 */),
-      missMeth("anorm.Sql.executeInsert1$default$3"/* new function */),
       missMeth("anorm.Sql.executeInsert1"/* new function */),
       missMeth("anorm.Sql.preparedStatement"/* new function */),
+      missMeth("anorm.Sql.asTry"/* private */),
+      missMeth("anorm.WithResult.asTry$default$2"/* private */),
+      missMeth("anorm.Sql.withResult"/* private */),
+      missMeth("anorm.Sql.executeInsert1$default$3"/* new default */),
+      missMeth("anorm.Sql.executeInsert2"/* new function */),
+      missMeth("anorm.Sql.executeInsert2$default$3"/* new default */),
+      missMeth("anorm.Cursor.onFirstRow"/* private */),
+      missMeth("anorm.Cursor.apply"/* private */),
+      ProblemFilters.exclude[MissingTypesProblem](
+        "anorm.MetaData$"/* private */),
       missMeth("anorm.BatchSql.withFetchSize"/* new function */),
       missMeth("anorm.SqlQueryResult.apply"/* deprecated 2.4 */),
       missMeth("anorm.SimpleSql.getFilledStatement"/* deprecated 2.3.6 */),
@@ -46,7 +56,11 @@ lazy val anorm = project
       missMeth("anorm.SimpleSql.single"/* deprecated 2.3.5 */),
       missMeth("anorm.SimpleSql.singleOpt"/* deprecated 2.3.5 */),
       missMeth("anorm.SimpleSql.apply"/* deprecated 2.4 */),
-      missMeth("anorm.WithResult.apply"/* deprecated 2.4 */)))
+      missMeth("anorm.WithResult.withResult"/* new function */),
+      missMeth("anorm.WithResult.foldWhile"/* new function */),
+      missMeth("anorm.WithResult.fold"/* new function */),
+      missMeth("anorm.WithResult.apply"/* deprecated 2.4 */),
+      missMeth("anorm.WithResult.asTry"/*new function */)))
   .settings({
     libraryDependencies ++= Seq(
       "com.jsuereth" %% "scala-arm" % "1.4",

--- a/core/src/main/scala/anorm/Cursor.scala
+++ b/core/src/main/scala/anorm/Cursor.scala
@@ -15,23 +15,13 @@ sealed trait Cursor {
 
 /** Cursor companion */
 object Cursor {
-  import scala.language.reflectiveCalls
-  import java.sql.ResultSetMetaData
-
   /**
    * Returns cursor for next row in given result set.
    *
    * @param rs Result set, must be before first row
    * @return None if there is no result in the set
    */
-  private[anorm] def apply(rs: ResultSet): Option[Cursor] =
-    if (!rs.next) None else Some(new Cursor {
-      val meta = metaData(rs)
-      val columns: List[Int] = List.range(1, meta.columnCount + 1)
-      val row = ResultRow(meta, columns.map(rs.getObject(_)))
-
-      lazy val next = apply(rs, meta, columns)
-    })
+  private[anorm] def apply(rs: ResultSet, aliaser: ColumnAliaser): Option[Cursor] = if (!rs.next) None else Some(withMeta(rs, MetaData.parse(rs, aliaser)))
 
   def unapply(cursor: Cursor): Option[(Row, Option[Cursor])] =
     Some(cursor.row -> cursor.next)
@@ -41,9 +31,9 @@ object Cursor {
    *
    * @param rs Result set, initialized on the first row
    */
-  private[anorm] def onFirstRow(rs: ResultSet): Option[Cursor] = try {
+  private[anorm] def onFirstRow(rs: ResultSet, aliaser: ColumnAliaser): Option[Cursor] = try {
     Some(new Cursor {
-      val meta = metaData(rs)
+      val meta = MetaData.parse(rs, aliaser)
       val columns: List[Int] = List.range(1, meta.columnCount + 1)
       val row = ResultRow(meta, columns.map(rs.getObject(_)))
 
@@ -53,30 +43,20 @@ object Cursor {
     case _: Throwable => Option.empty[Cursor]
   }
 
+  /** Returns a cursor with already parsed metadata. */
+  private def withMeta(rs: ResultSet, _meta: MetaData): Cursor = new Cursor {
+    val meta = _meta
+    val columns: List[Int] = List.range(1, meta.columnCount + 1)
+    val row = ResultRow(meta, columns.map(rs.getObject(_)))
+
+    lazy val next = apply(rs, meta, columns)
+  }
+
   /** Creates cursor after the first one, as meta data is already known. */
   private def apply(rs: ResultSet, meta: MetaData, columns: List[Int]): Option[Cursor] = if (!rs.next) None else Some(new Cursor {
     val row = ResultRow(meta, columns.map(rs.getObject(_)))
-    def next = apply(rs)
+    def next = if (!rs.next) None else Some(withMeta(rs, meta))
   })
-
-  /** Returns metadata for given result set. */
-  private def metaData(rs: ResultSet): MetaData = {
-    val meta = rs.getMetaData()
-    val nbColumns = meta.getColumnCount()
-    MetaData(List.range(1, nbColumns + 1).map(i =>
-      MetaDataItem(column = ColumnName({
-
-        // HACK FOR POSTGRES - Fix in https://github.com/pgjdbc/pgjdbc/pull/107
-        if (meta.getClass.getName.startsWith("org.postgresql.")) {
-          meta.asInstanceOf[{ def getBaseTableName(i: Int): String }].getBaseTableName(i)
-        } else {
-          meta.getTableName(i)
-        }
-
-      } + "." + meta.getColumnName(i), alias = Option(meta.getColumnLabel(i))),
-        nullable = meta.isNullable(i) == ResultSetMetaData.columnNullable,
-        clazz = meta.getColumnClassName(i))))
-  }
 
   /** Result row to be parsed. */
   private case class ResultRow(

--- a/core/src/main/scala/anorm/MetaData.scala
+++ b/core/src/main/scala/anorm/MetaData.scala
@@ -1,0 +1,153 @@
+package anorm
+
+/**
+ * @param qualified the qualified column name
+ * @param alias the column alias
+ */
+case class ColumnName(qualified: String, alias: Option[String])
+
+/**
+ * @param column the name of the column
+ * @param nullable true if the column is nullable
+ * @param clazz the class of the JDBC column value
+ */
+case class MetaDataItem(column: ColumnName, nullable: Boolean, clazz: String)
+
+private[anorm] case class MetaData(ms: List[MetaDataItem]) {
+  /** Returns meta data for specified column. */
+  def get(columnName: String): Option[MetaDataItem] = {
+    val key = columnName.toUpperCase
+    aliasedDictionary.get(key).
+      orElse(dictionary2 get key).orElse(dictionary get key)
+  }
+
+  private lazy val dictionary: Map[String, MetaDataItem] =
+    ms.map(m => m.column.qualified.toUpperCase() -> m).toMap
+
+  private lazy val dictionary2: Map[String, MetaDataItem] =
+    ms.map(m => {
+      val column = m.column.qualified.split('.').last;
+      column.toUpperCase() -> m
+    }).toMap
+
+  private lazy val aliasedDictionary: Map[String, MetaDataItem] =
+    ms.flatMap(m =>
+      m.column.alias.map(a => Map(a.toUpperCase() -> m)).getOrElse(Map.empty)
+    ).toMap
+
+  lazy val columnCount = ms.size
+
+  lazy val availableColumns: List[String] =
+    ms.flatMap(i => i.column.qualified :: i.column.alias.toList)
+
+}
+
+/** Allows to define or overwrite the alias for a column. */
+trait ColumnAliaser extends Function[(Int, ColumnName), Option[String]] {
+  /**
+   * Returns the alias for the specified column, if defined.
+   *
+   * @param column the position (>= 1) and the name of the column
+   */
+  def apply(column: (Int, ColumnName)): Option[String]
+}
+
+object ColumnAliaser {
+  import scala.collection.immutable.Set
+
+  private class Default(
+      f: PartialFunction[(Int, ColumnName), String]) extends ColumnAliaser {
+
+    def apply(column: (Int, ColumnName)) = f.lift(column)
+  }
+
+  /**
+   * Initializes an aliaser from a given partial function.
+   *
+   * {{{
+   * ColumnAliaser({
+   *   case (1, cn) => "my_id"
+   *   case (_, ColumnName(".foo", _)) => "prefix.foo"
+   * })
+   * }}}
+   */
+  def apply(f: PartialFunction[(Int, ColumnName), String]): ColumnAliaser =
+    new Default(f)
+
+  object empty extends ColumnAliaser {
+    def apply(column: (Int, ColumnName)) = Option.empty[String]
+  }
+
+  /**
+   * @param positions the column positions (>= 1)
+   * @param as function to determine the alias for the matching columns
+   *
+   * {{{
+   * ColumnAliaser.perPositions((2 to 3).toSet) {
+   *   case (2, _) => "prefix.foo"
+   *   case _ => "bar"
+   * }
+   * }}}
+   */
+  def perPositions(positions: Set[Int])(as: ((Int, ColumnName)) => String): ColumnAliaser = new Default({
+    case c @ (pos, cn) if (positions contains pos) => as(c)
+  })
+
+  /**
+   * @param positions the column positions (>= 1)
+   * @param prefix the prefix to be prepended to the aliases of the matching columns
+   * @param suffix the suffix to be appended to the aliases (default: `""`)
+   *
+   * {{{
+   * ColumnAliaser.withPattern((2 to 3).toSet, "prefix.")
+   * }}}
+   */
+  def withPattern(positions: Set[Int], prefix: String, suffix: String = ""): ColumnAliaser = perPositions(positions) {
+    case (_, ColumnName(_, Some(alias))) => s"$prefix$alias$suffix"
+    case (_, ColumnName(_, _)) => s"$prefix$suffix"
+  }
+
+  /**
+   * @param prefix the prefix to be prepended to the aliases of the matching columns
+   * @param suffix the suffix to be appended to the aliases (default: `""`)
+   * @param positions the column positions (>= 1); duplicate are merged
+   *
+   * {{{
+   * ColumnAliaser.withPattern((2 to 3).toSet, "prefix.")
+   * }}}
+   */
+  def withPattern1(prefix: String, suffix: String = "")(positions: Int*): ColumnAliaser = withPattern(positions.toSet, prefix, suffix)
+}
+
+private[anorm] object MetaData {
+  import java.sql.{ ResultSet, ResultSetMetaData }
+  import scala.language.reflectiveCalls
+
+  private type PgMeta = { def getBaseTableName(i: Int): String }
+
+  /** Returns metadata for given result set. */
+  def parse(rs: ResultSet, as: ColumnAliaser): MetaData = {
+    val meta = rs.getMetaData()
+    val nbColumns = meta.getColumnCount()
+    MetaData(List.range(1, nbColumns + 1).map { i =>
+      val cn = ColumnName({
+        if (meta.getClass.getName startsWith "org.postgresql.") {
+          // HACK FOR POSTGRES:
+          // Fix in https://github.com/pgjdbc/pgjdbc/pull/107
+
+          meta.asInstanceOf[PgMeta].getBaseTableName(i)
+        } else {
+          meta.getTableName(i)
+        }
+
+      } + "." + meta.getColumnName(i),
+        alias = Option(meta.getColumnLabel(i)))
+
+      val colName = as(i, cn).fold(cn)(a => cn.copy(alias = Some(a)))
+
+      MetaDataItem(column = colName,
+        nullable = meta.isNullable(i) == ResultSetMetaData.columnNullable,
+        clazz = meta.getColumnClassName(i))
+    })
+  }
+}

--- a/core/src/main/scala/anorm/SqlResult.scala
+++ b/core/src/main/scala/anorm/SqlResult.scala
@@ -32,6 +32,7 @@ case class Error(msg: SqlRequestError) extends SqlResult[Nothing]
 
 private[anorm] trait WithResult {
   import java.sql.Connection
+  import scala.util.Try
 
   /** ResultSet is initialized on first row (JDBC degraded) */
   def resultSetOnFirstRow: Boolean
@@ -48,6 +49,8 @@ private[anorm] trait WithResult {
    * @see #foldWhile
    * @see #withResult
    */
+  @deprecated(message = "Use `fold` with empty [[ColumnAliaser]]",
+    since = "2.5.1")
   def fold[T](z: => T)(op: (T, Row) => T)(implicit connection: Connection): Either[List[Throwable], T] = {
     @annotation.tailrec
     def go(c: Option[Cursor], cur: T): T = c match {
@@ -59,6 +62,26 @@ private[anorm] trait WithResult {
   }
 
   /**
+   * Aggregates over all rows using the specified operator.
+   *
+   * @param z the start value
+   * @param aliaser the column aliaser
+   * @param op Aggregate operator
+   * @return Either list of failures at left, or aggregated value
+   * @see #foldWhile
+   * @see #withResult
+   */
+  def fold[T](z: => T, aliaser: ColumnAliaser)(op: (T, Row) => T)(implicit connection: Connection): Either[List[Throwable], T] = {
+    @annotation.tailrec
+    def go(c: Option[Cursor], cur: T): T = c match {
+      case Some(cursor) => go(cursor.next, op(cur, cursor.row))
+      case _ => cur
+    }
+
+    withResult(go(_, z), aliaser)
+  }
+
+  /**
    * Aggregates over part of or the while row stream,
    * using the specified operator.
    *
@@ -67,6 +90,8 @@ private[anorm] trait WithResult {
    * @return Either list of failures at left, or aggregated value
    * @see #withResult
    */
+  @deprecated(message = "Use `foldWhile` with empty [[ColumnAliaser]]",
+    since = "2.5.1")
   def foldWhile[T](z: => T)(op: (T, Row) => (T, Boolean))(implicit connection: Connection): Either[List[Throwable], T] = {
     @annotation.tailrec
     def go(c: Option[Cursor], cur: T): T = c match {
@@ -78,6 +103,47 @@ private[anorm] trait WithResult {
 
     withResult(go(_, z))
   }
+
+  /**
+   * Aggregates over part of or the while row stream,
+   * using the specified operator.
+   *
+   * @param z the start value
+   * @param aliaser the column aliaser
+   * @param op Aggregate operator. Returns aggregated value along with true if aggregation must process next value, or false to stop with current value.
+   * @return Either list of failures at left, or aggregated value
+   * @see #withResult
+   */
+  def foldWhile[T](z: => T, aliaser: ColumnAliaser)(op: (T, Row) => (T, Boolean))(implicit connection: Connection): Either[List[Throwable], T] = {
+    @annotation.tailrec
+    def go(c: Option[Cursor], cur: T): T = c match {
+      case Some(cursor) =>
+        val (v, cont) = op(cur, cursor.row)
+        if (!cont) v else go(cursor.next, v)
+      case _ => cur
+    }
+
+    withResult(go(_, z), aliaser)
+  }
+
+  /**
+   * Processes all or some rows from current result.
+   *
+   * @param op Operation applied with row cursor
+   * @param aliaser the column aliaser
+   *
+   * {{{
+   * @annotation.tailrec
+   * def go(c: Option[Cursor], l: List[Row]): List[Row] = c match {
+   *   case Some(cursor) => go(cursor.next, l :+ cursor.row)
+   *   case _ => l
+   * }
+   *
+   * val l: Either[List[Throwable], List[Row]] =
+   *   SQL"SELECT * FROM Test".withResult(go)
+   * }}}
+   */
+  def withResult[T](op: Option[Cursor] => T)(implicit connection: Connection): Either[List[Throwable], T] = withResult[T](op, ColumnAliaser.empty)
 
   /**
    * Processes all or some rows from current result.
@@ -95,13 +161,23 @@ private[anorm] trait WithResult {
    *   SQL"SELECT * FROM Test".withResult(go)
    * }}}
    */
-  def withResult[T](op: Option[Cursor] => T)(implicit connection: Connection): Either[List[Throwable], T] = Sql.withResult(resultSet(connection), resultSetOnFirstRow)(op).acquireFor(identity)
+  def withResult[T](op: Option[Cursor] => T, aliaser: ColumnAliaser)(implicit connection: Connection): Either[List[Throwable], T] = Sql.withResult(resultSet(connection), resultSetOnFirstRow, aliaser)(op).acquireFor(identity)
 
   /**
    * Converts this query result as `T`, using parser.
+   *
+   * @param parser the result parser
+   * @see #asTry
    */
   def as[T](parser: ResultSetParser[T])(implicit connection: Connection): T =
-    Sql.asTry(parser, resultSet(connection), resultSetOnFirstRow).get
-  // TODO: Safe alternative
+    asTry[T](parser, ColumnAliaser.empty).get
+
+  /**
+   * Converts this query result as `T`, using parser.
+   *
+   * @param parser the result parser
+   * @param aliaser the column aliaser
+   */
+  def asTry[T](parser: ResultSetParser[T], aliaser: ColumnAliaser = ColumnAliaser.empty)(implicit connection: Connection): Try[T] = Sql.asTry(parser, resultSet(connection), resultSetOnFirstRow, aliaser)
 
 }

--- a/core/src/test/scala/anorm/CursorSpec.scala
+++ b/core/src/test/scala/anorm/CursorSpec.scala
@@ -8,20 +8,20 @@ object CursorSpec extends org.specs2.mutable.Specification {
 
   "Cursor" should {
     "not be returned when there is no result" in {
-      Cursor(stringList.resultSet) aka "cursor" must beNone
+      Cursor(stringList.resultSet, ColumnAliaser.empty) aka "cursor" must beNone
     }
 
     "be returned for one row" in {
-      Cursor(stringList :+ "A" resultSet) aka "cursor" must beSome.
-        which { cur =>
+      Cursor(stringList :+ "A" resultSet, ColumnAliaser.empty).
+        aka("cursor") must beSome.which { cur =>
           cur.row[String]("str") aka "row" must_== "A" and (
             cur.next aka "after first" must beNone)
         }
     }
 
     "be return for three rows" in {
-      Cursor(stringList :+ "red" :+ "green" :+ "blue" resultSet).
-        aka("cursor") must beSome.which { first =>
+      Cursor(stringList :+ "red" :+ "green" :+ "blue" resultSet,
+        ColumnAliaser.empty) aka "cursor" must beSome.which { first =>
           first.row[String]("str") aka "row #1" must_== "red" and (
             first.next aka "after first" must beSome.which { snd =>
               snd.row[String]("str") aka "row #2" must_== "green" and (
@@ -34,12 +34,13 @@ object CursorSpec extends org.specs2.mutable.Specification {
     }
 
     "match pattern" in {
-      Cursor(stringList :+ "Foo" :+ "Bar" resultSet) must beSome[Cursor].like {
-        case Cursor(row1, b) => row1[String](1) must_== "Foo" and (
-          b must beSome[Cursor].like {
-            case Cursor(row2, None) => row2[String](1) must_== "Bar"
-          })
-      }
+      Cursor(stringList :+ "Foo" :+ "Bar" resultSet, ColumnAliaser.empty).
+        aka("cursor") must beSome[Cursor].like {
+          case Cursor(row1, b) => row1[String](1) must_== "Foo" and (
+            b must beSome[Cursor].like {
+              case Cursor(row2, None) => row2[String](1) must_== "Bar"
+            })
+        }
     }
   }
 

--- a/core/src/test/scala/anorm/MetaDataSpec.scala
+++ b/core/src/test/scala/anorm/MetaDataSpec.scala
@@ -1,24 +1,94 @@
 package anorm
 
+import acolyte.jdbc.RowLists.rowList3
+import acolyte.jdbc.Implicits._
+
 object MetaDataSpec extends org.specs2.mutable.Specification {
   "Meta-data" title
 
   "Meta-data" should {
-    val item1 = MetaDataItem(ColumnName(
-      "TEST1.FOO", Some("ALI")), true, "java.lang.String")
+    "support column aliases" in {
+      val item1 = MetaDataItem(ColumnName(
+        "TEST1.FOO", Some("ALI")), true, "java.lang.String")
 
-    val item2 = MetaDataItem(ColumnName(
-      "TEST1.FOO", Some("FOO")), true, "java.lang.String")
+      val item2 = MetaDataItem(ColumnName(
+        "TEST1.FOO", Some("FOO")), true, "java.lang.String")
 
-    val item3 = MetaDataItem(ColumnName(
-      "TEST1.FOO", Some("IAS")), true, "java.lang.String")
+      val item3 = MetaDataItem(ColumnName(
+        "TEST1.FOO", Some("IAS")), true, "java.lang.String")
 
-    val meta = MetaData(List(item1, item2, item3))
+      val meta1 = MetaData(List(item1, item2, item3))
 
-    "be support colum aliases" in {
-      meta.get("ALI") aka "ALI" must beSome(item1) and (
-        meta.get("FOO") aka "FOO" must beSome(item2)) and (
-          meta.get("IAS") aka "IAS" must beSome(item3))
+      meta1.get("ALI") aka "ALI" must beSome(item1) and (
+        meta1.get("FOO") aka "FOO" must beSome(item2)) and (
+          meta1.get("IAS") aka "IAS" must beSome(item3))
+    }
+
+    "be parsed from resultset" >> {
+      import scala.language.existentials
+      @inline def rs = (fooBarTable :+ (1L, "lorem", 3)).getRowList.resultSet()
+
+      val item1 = MetaDataItem(ColumnName(
+        ".id", Some("id")), false, "long")
+
+      val item2 = MetaDataItem(ColumnName(
+        ".foo", Some("foo")), false, "java.lang.String")
+
+      val item3 = MetaDataItem(ColumnName(
+        ".bar", Some("bar")), false, "int")
+
+      "without aliaser" in {
+        MetaData.parse(rs, ColumnAliaser.empty).
+          aka("metadata") must_== MetaData(List(item1, item2, item3))
+      }
+
+      "with partial aliaser" in {
+        val itemA = item1.copy(column =
+          item1.column.copy(alias = Some("my_id")))
+        val itemB = item2.copy(column =
+          item2.column.copy(alias = Some("prefix.foo")))
+
+        MetaData.parse(rs, ColumnAliaser({
+          case (1, cn) => "my_id"
+          case (_, ColumnName(".foo", _)) => "prefix.foo"
+        })) must_== MetaData(List(itemA, itemB, item3))
+      }
+
+      "with positional aliaser" in {
+        val itemB = item2.copy(column =
+          item2.column.copy(alias = Some("prefix.foo")))
+        val itemC = item3.copy(column =
+          item3.column.copy(alias = Some("barbar")))
+
+        MetaData.parse(rs, ColumnAliaser.perPositions((2 to 3).toSet) {
+          case (2, _) => "prefix.foo"
+          case _ => "barbar"
+        }) must_== MetaData(List(item1, itemB, itemC))
+      }
+
+      "with pattern aliaser #1" in {
+        val itemB = item2.copy(column =
+          item2.column.copy(alias = Some("prefix.foo")))
+        val itemC = item3.copy(column =
+          item3.column.copy(alias = Some("prefix.bar")))
+
+        MetaData.parse(rs, ColumnAliaser.
+          withPattern((2 to 3).toSet, "prefix.")) must_== MetaData(
+          List(item1, itemB, itemC))
+      }
+
+      "with pattern aliaser #2" in {
+        val itemB = item2.copy(column =
+          item2.column.copy(alias = Some("prefix.foo")))
+
+        MetaData.parse(rs, ColumnAliaser.
+          withPattern1("prefix.")(2, 2)) must_== MetaData(
+          List(item1, itemB, item3))
+      }
     }
   }
+
+  lazy val fooBarTable = rowList3(
+    classOf[Long] -> "id", classOf[String] -> "foo", classOf[Int] -> "bar")
+
 }


### PR DESCRIPTION
As JDBC doesn't [support table alias](https://github.com/pgjdbc/pgjdbc/issues/522), it would be nice to be able to define aliases for some range of columns for the result parsing (e.g. result from join over the same columns but from different table aliases).

Considering the following query result, JDBC doesn't make it possible (as `ResultSetMetaData.getTableName` doesn't indicate the table aliases, and there is not `.getTableLabel`) to have distinct names or aliases for the same columns coming from the different table aliases `t1` and `t2`.

```
=> SELECT * FROM test t1 JOIN (SELECT * FROM test WHERE parent_id ISNULL) t2 ON t1.parent_id=t2.id WHERE t1.id='bar';
 id  | value  | parent_id | id  | value  | parent_id 
-----+--------+-----------+-----+--------+-----------
 bar | value2 | foo       | foo | value1 | 
(1 row)
```

With the `ColumnAliaser` introduced there, it's possible to a workaround as follows.

```scala
import anorm._

val parser: RowParser[(String, String, String, Option[String])] = SqlParser.str("id") ~ SqlParser.str("value") ~ SqlParser.str("parent.value") ~ SqlParser.str("parent.parent_id").? map(SqlParser.flatten)

val aliaser: ColumnAliaser = ColumnAliaser.withPattern((3 to 6).toSet, "parent.")

val res: Try[(String, String, String, Option[String])] = SQL"""SELECT * FROM test t1 JOIN (SELECT * FROM test WHERE parent_id ISNULL) t2 ON t1.parent_id=t2.id WHERE t1.id=${"bar"}""".asTry(parser.single, aliaser)

res.foreach {
  case (id, value, parentVal, grandPaId) => ???
}
```