### PR TITLE
Use separate iteratees library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{
   binaryIssueFilters, previousArtifacts
 }
 
-val PlayVersion = playVersion(sys.props.getOrElse("play.version", "2.5.0"))
+val PlayVersion = playVersion(sys.props.getOrElse("play.version", "2.5.3"))
 
 lazy val acolyteVersion = "1.0.36-j7p"
 
@@ -80,9 +80,9 @@ lazy val `anorm-iteratee` = (project in file("iteratee"))
   .enablePlugins(PlayLibrary)
   .settings(scalariformSettings: _*)
   .settings(
-  previousArtifacts := Set.empty,
+    previousArtifacts := Set.empty,
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-iteratees" % PlayVersion % "provided",
+      "com.typesafe.play" %% "play-iteratees" % "2.6.0",
       "org.eu.acolyte" %% "jdbc-scala" % acolyteVersion % Test      
     ) ++ Seq(
       "specs2-core",


### PR DESCRIPTION
This allows us to build against the Play nightlies, as 2.6.x no longer has iteratees and it is a separate project.

I also created the 2.5.x branch so we can do releases from that instead of master.