### PR TITLE
Fix column resolution for qualified name

### DIFF
--- a/core/src/main/scala/anorm/SqlRequestError.scala
+++ b/core/src/main/scala/anorm/SqlRequestError.scala
@@ -36,7 +36,10 @@ object ColumnNotFound {
     ColumnNotFound(column, row.metaData.availableColumns)
 }
 
-case class UnexpectedNullableFound(message: String) extends SqlRequestError
+case class UnexpectedNullableFound(reason: String) extends SqlRequestError {
+  lazy val message = s"UnexpectedNullableFound($reason)"
+  override lazy val toString = message
+}
 
 case class SqlMappingError(reason: String) extends SqlRequestError {
   lazy val message = s"SqlMappingError($reason)"

--- a/core/src/test/scala/anorm/SqlRequestErrorSpec.scala
+++ b/core/src/test/scala/anorm/SqlRequestErrorSpec.scala
@@ -13,7 +13,8 @@ object SqlRequestErrorSpec extends org.specs2.mutable.Specification {
   "UnexpectedNullableFound" should {
     "be converted to Failure" in {
       UnexpectedNullableFound("Foo message").toFailure must beFailedTry.
-        withThrowable[AnormException]("Foo message")
+        withThrowable[AnormException](
+          "UnexpectedNullableFound\\(Foo message\\)")
     }
   }
 


### PR DESCRIPTION
In case of a dotted/qualified name (e.g. `table.column`), first try to resolved using the qualified names of the resultset metadata, instead of first trying the alias (default priority for other cases).