### PR TITLE
Runtime Exception when SQL ~ LIKE $param + '%'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: scala
 jdk:
   - oraclejdk8
-before_script:
-- mkdir -p $HOME/.sbt/launchers/0.13.8/
-- curl -L -o $HOME/.sbt/launchers/0.13.8/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.8/sbt-launch.jar
+sudo: false
+cache:
+  directories:
+  - $HOME/.ivy2
+  - $HOME/.sbt
 script:
   - sbt +mimaReportBinaryIssues +test docs/test

--- a/akka/src/test/resources/reference.conf
+++ b/akka/src/test/resources/reference.conf
@@ -1,0 +1,3 @@
+akka {
+  loglevel = "OFF"
+}

--- a/akka/src/test/scala/anorm/AkkaStreamSpec.scala
+++ b/akka/src/test/scala/anorm/AkkaStreamSpec.scala
@@ -2,30 +2,34 @@ package anorm
 
 import java.sql.{ Connection, ResultSet }
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.duration._
 
 import scala.collection.immutable.Seq
 
 import akka.NotUsed
 import akka.stream.scaladsl.{ Sink, Source }
 
+import org.specs2.concurrent.{ ExecutionEnv => EE }
+
 import acolyte.jdbc.AcolyteDSL.withQueryResult
 import acolyte.jdbc.RowLists.stringList
 import acolyte.jdbc.Implicits._
 
-object AkkaStreamSpec extends org.specs2.mutable.Specification {
+class AkkaStreamSpec extends org.specs2.mutable.Specification {
   "Akka Stream" title
 
   implicit lazy val system = akka.actor.ActorSystem("knox-core-tests")
   implicit def materializer = akka.stream.ActorMaterializer.create(system)
 
   "Akka Stream" should {
-    "expose the query result as source" in (
-      withQueryResult(stringList :+ "A" :+ "B" :+ "C")) { implicit con =>
+    "expose the query result as source" in { implicit ee: EE =>
+      withQueryResult(stringList :+ "A" :+ "B" :+ "C") { implicit con =>
         AkkaStream.source(SQL"SELECT * FROM Test", SqlParser.scalar[String]).
           runWith(Sink.seq[String]) must beEqualTo(Seq("A", "B", "C")).
-          await(1000)
+          await(0, 5.second)
       }
+    }
 
     "manage resources" in {
       def run[T](sink: Sink[String, T])(implicit c: Connection) = {
@@ -36,20 +40,21 @@ object AkkaStreamSpec extends org.specs2.mutable.Specification {
         })
       }
 
-      def runAsync[T](sink: Sink[String, Future[T]])(implicit c: Connection) = {
+      def runAsync[T](sink: Sink[String, Future[T]])(implicit ec: ExecutionContext, c: Connection) = {
         val graph = source(SQL"SELECT * FROM Test", SqlParser.scalar[String])
 
         Source.fromGraph(graph).runWith(sink).map { _ => graph.resultSet }
       }
 
-      "on success" in (
-        withQueryResult(stringList :+ "A" :+ "B" :+ "C")) { implicit con =>
+      "on success" in { implicit ee: EE =>
+        withQueryResult(stringList :+ "A" :+ "B" :+ "C") { implicit con =>
           runAsync(Sink.seq[String]) must beLike[ResultSet] {
             case rs => rs.isClosed must beTrue and (
               rs.getStatement.isClosed must beTrue) and (
                 con.isClosed must beFalse)
-          }.await(1000)
+          }.await(0, 5.second)
         }
+      }
 
       "on cancellation" in (
         withQueryResult(stringList :+ "A" :+ "B" :+ "C")) { implicit con =>

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,8 @@ lazy val anorm = project
   .settings(
   scalacOptions += "-Xlog-free-terms",
     binaryIssueFilters ++= Seq(
+      // was private:
+      ProblemFilters.exclude[FinalClassProblem]("anorm.Sql$MissingParameter"),
       missMeth("anorm.DefaultParameterValue.stringValue"/* deprecated */),
       missMeth("anorm.ParameterValue.stringValue"/* deprecated */),
       missMeth("anorm.BatchSql.apply"/* was deprecated */),
@@ -80,7 +82,7 @@ lazy val anorm = project
     ) ++ Seq(
       "specs2-core",
       "specs2-junit"
-    ).map("org.specs2" %% _ % "3.6.4" % Test)
+    ).map("org.specs2" %% _ % "3.8.3" % Test)
   }).dependsOn(`anorm-tokenizer`)
 
 lazy val `anorm-iteratee` = (project in file("iteratee"))
@@ -94,7 +96,7 @@ lazy val `anorm-iteratee` = (project in file("iteratee"))
     ) ++ Seq(
       "specs2-core",
       "specs2-junit"
-    ).map("org.specs2" %% _ % "2.4.9" % Test)
+    ).map("org.specs2" %% _ % "3.8.3" % Test)
   ).dependsOn(anorm)
 
 lazy val `anorm-akka` = (project in file("akka"))
@@ -103,12 +105,12 @@ lazy val `anorm-akka` = (project in file("akka"))
   .settings(
     previousArtifacts := Set.empty,
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-stream" % "2.4.4" % "provided",
+      "com.typesafe.akka" %% "akka-stream" % "2.4.7" % "provided",
       "org.eu.acolyte" %% "jdbc-scala" % acolyteVersion % Test
     ) ++ Seq(
       "specs2-core",
       "specs2-junit"
-    ).map("org.specs2" %% _ % "2.4.9" % Test)
+    ).map("org.specs2" %% _ % "3.8.3" % Test)
   ).dependsOn(anorm)
 
 lazy val `anorm-parent` = (project in file("."))

--- a/core/src/test/scala/anorm/AnormSpec.scala
+++ b/core/src/test/scala/anorm/AnormSpec.scala
@@ -20,7 +20,7 @@ import acolyte.jdbc.Implicits._
 
 import SqlParser.scalar
 
-object AnormSpec extends Specification with H2Database with AnormTest {
+class AnormSpec extends Specification with H2Database with AnormTest {
   "Anorm" title
 
   lazy val fooBarTable = rowList3(

--- a/core/src/test/scala/anorm/BatchSqlSpec.scala
+++ b/core/src/test/scala/anorm/BatchSqlSpec.scala
@@ -2,7 +2,7 @@ package anorm
 
 import acolyte.jdbc.AcolyteDSL
 
-object BatchSqlSpec
+class BatchSqlSpec
     extends org.specs2.mutable.Specification with H2Database {
 
   "Batch SQL" title

--- a/core/src/test/scala/anorm/ColumnSpec.scala
+++ b/core/src/test/scala/anorm/ColumnSpec.scala
@@ -31,7 +31,7 @@ import acolyte.jdbc.Implicits._
 
 import SqlParser.{ byte, double, float, int, long, scalar, short }
 
-object ColumnSpec
+class ColumnSpec
     extends org.specs2.mutable.Specification with JodaColumnSpec {
 
   "Column" title

--- a/core/src/test/scala/anorm/CursorSpec.scala
+++ b/core/src/test/scala/anorm/CursorSpec.scala
@@ -3,7 +3,7 @@ package anorm
 import acolyte.jdbc.RowLists.rowList1
 import acolyte.jdbc.Implicits._
 
-object CursorSpec extends org.specs2.mutable.Specification {
+class CursorSpec extends org.specs2.mutable.Specification {
   "Cursor" title
 
   "Cursor" should {

--- a/core/src/test/scala/anorm/FunctionAdapterSpec.scala
+++ b/core/src/test/scala/anorm/FunctionAdapterSpec.scala
@@ -6,7 +6,7 @@ import acolyte.jdbc.RowLists._
 import acolyte.jdbc.AcolyteDSL.withQueryResult
 import acolyte.jdbc.Implicits._
 
-object FunctionAdapterSpec extends org.specs2.mutable.Specification {
+class FunctionAdapterSpec extends org.specs2.mutable.Specification {
   "Function flattener" title
 
   "Single column" should {

--- a/core/src/test/scala/anorm/H2Database.scala
+++ b/core/src/test/scala/anorm/H2Database.scala
@@ -4,7 +4,6 @@ import java.sql.{ DriverManager, Connection }
 import scala.util.Random
 
 trait H2Database {
-
   def withH2Database[R](block: Connection => R): R = {
     val url = "jdbc:h2:mem:test" + Random.alphanumeric.take(6).mkString("")
     val connection = DriverManager.getConnection(url, "sa", "")

--- a/core/src/test/scala/anorm/JavaTimeSpec.scala
+++ b/core/src/test/scala/anorm/JavaTimeSpec.scala
@@ -7,8 +7,7 @@ import acolyte.jdbc.RowLists._
 import acolyte.jdbc.Implicits._
 import org.specs2.mutable.Specification
 
-object JavaTimeColumnSpec extends Specification {
-
+class JavaTimeColumnSpec extends Specification {
   import SqlParser.scalar
 
   "Column mapped as Java8 instant" should {

--- a/core/src/test/scala/anorm/JodaSpec.scala
+++ b/core/src/test/scala/anorm/JodaSpec.scala
@@ -199,7 +199,7 @@ trait JodaColumnSpec { specs: Specification =>
   }
 }
 
-trait JodaParameterSpec { specs: ParameterSpec.type =>
+trait JodaParameterSpec { specs: ParameterSpec =>
   import JodaParameterMetaData._
 
   lazy val dateTime1 = new DateTime(Date1.getTime)

--- a/core/src/test/scala/anorm/MetaDataSpec.scala
+++ b/core/src/test/scala/anorm/MetaDataSpec.scala
@@ -3,7 +3,7 @@ package anorm
 import acolyte.jdbc.RowLists.rowList3
 import acolyte.jdbc.Implicits._
 
-object MetaDataSpec extends org.specs2.mutable.Specification {
+class MetaDataSpec extends org.specs2.mutable.Specification {
   "Meta-data" title
 
   "Meta-data" should {

--- a/core/src/test/scala/anorm/ParameterMetaDataSpec.scala
+++ b/core/src/test/scala/anorm/ParameterMetaDataSpec.scala
@@ -17,7 +17,7 @@ import java.math.{ BigDecimal => JBigDec, BigInteger }
 
 import java.sql.Timestamp
 
-object ParameterMetaDataSpec extends org.specs2.mutable.Specification {
+class ParameterMetaDataSpec extends org.specs2.mutable.Specification {
   "Parameter metadata" title
 
   "Metadata" should {

--- a/core/src/test/scala/anorm/ParameterSpec.scala
+++ b/core/src/test/scala/anorm/ParameterSpec.scala
@@ -28,7 +28,7 @@ import acolyte.jdbc.{
 import acolyte.jdbc.AcolyteDSL.{ connection, handleStatement }
 import acolyte.jdbc.Implicits._
 
-object ParameterSpec
+class ParameterSpec
     extends org.specs2.mutable.Specification with JodaParameterSpec {
 
   "Parameter" title

--- a/core/src/test/scala/anorm/RowSpec.scala
+++ b/core/src/test/scala/anorm/RowSpec.scala
@@ -6,7 +6,7 @@ import acolyte.jdbc.AcolyteDSL.withQueryResult
 import acolyte.jdbc.RowLists.{ rowList2, rowList1, stringList }
 import acolyte.jdbc.Implicits._
 
-object RowSpec extends org.specs2.mutable.Specification {
+class RowSpec extends org.specs2.mutable.Specification {
   "Row" title
 
   "List of column values" should {

--- a/core/src/test/scala/anorm/SqlRequestErrorSpec.scala
+++ b/core/src/test/scala/anorm/SqlRequestErrorSpec.scala
@@ -1,6 +1,6 @@
 package anorm
 
-object SqlRequestErrorSpec extends org.specs2.mutable.Specification {
+class SqlRequestErrorSpec extends org.specs2.mutable.Specification {
   "SQL request error" title
 
   "ColumnNotFound" should {

--- a/core/src/test/scala/anorm/SqlResultSpec.scala
+++ b/core/src/test/scala/anorm/SqlResultSpec.scala
@@ -7,7 +7,7 @@ import acolyte.jdbc.AcolyteDSL.{ connection, handleQuery, withQueryResult }
 import acolyte.jdbc.RowLists.{ rowList1, rowList2, stringList }
 import acolyte.jdbc.Implicits._
 
-object SqlResultSpec extends org.specs2.mutable.Specification with H2Database {
+class SqlResultSpec extends org.specs2.mutable.Specification with H2Database {
   "SQL result" title
 
   "For-comprehension over result" should {

--- a/core/src/test/scala/anorm/StatementParserSpec.scala
+++ b/core/src/test/scala/anorm/StatementParserSpec.scala
@@ -9,7 +9,7 @@ import acolyte.jdbc.RowLists.stringList
 import acolyte.jdbc.AcolyteDSL.{ connection, handleQuery, withQueryResult }
 import acolyte.jdbc.Implicits._
 
-object StatementParserSpec extends org.specs2.mutable.Specification {
+class StatementParserSpec extends org.specs2.mutable.Specification {
   "SQL statement parser" title
 
   "Statement" should {
@@ -58,49 +58,75 @@ object StatementParserSpec extends org.specs2.mutable.Specification {
     }
   }
 
-  /* TODO: Refactor
-  "Rewriting" should {
+  "Tokenized statement" should {
     "return some prepared query with updated statement" in {
       val stmt1 = TokenizedStatement(List(TokenGroup(List(StringToken("SELECT * FROM t WHERE c IN (")), Some("cs")), TokenGroup(List(StringToken(") AND id = ")), Some("id"))), List("cs", "id"))
 
-      val stmt2 = TokenizedStatement(List(TokenGroup(List(StringToken("SELECT * FROM t WHERE c IN ("), StringToken("?, ?"), StringToken(") AND id = ")), Some("id"))), List("cs", "id"))
+      val stmt2 = TokenizedStatement(List(TokenGroup(List(StringToken("SELECT * FROM t WHERE c IN ("), StringToken("?, ?"), StringToken(") AND id = ")), Some("id"))), List("cs_1", "cs_2", "id"))
 
       val stmt3 = TokenizedStatement(List(TokenGroup(List(StringToken("SELECT * FROM t WHERE c IN ("), StringToken("?, ?"), StringToken(") AND id = "), StringToken("?")), None)), List("cs", "id"))
 
-      TokenizedStatement.rewrite(stmt1, "?, ?") must beSuccessfulTry.like {
-        case rw1 =>
-          rw1 aka "first rewrite" mustEqual stmt2 and (
-            TokenizedStatement.rewrite(rw1, "?").
-            aka("second rewrite") must beSuccessfulTry.like {
-              case rw2 => rw2 aka "final statement" must_== stmt3
-            })
+      // ---
+
+      Sql.prepareQuery(stmt1.tokens, stmt1.names, Map[String, ParameterValue]("cs" -> List("a", "b"), "id" -> 3), 0, new StringBuilder(), List.empty[(Int, ParameterValue)]) must beSuccessfulTry.like {
+        case prepared1 =>
+          prepared1._2 aka "parameters #1" must_== List[(Int, ParameterValue)](
+            0 -> List("a", "b"), 2 -> 3) and {
+              Sql.prepareQuery(stmt2.tokens, stmt2.names, Map[String, ParameterValue]("cs_1" -> "a", "cs_2" -> "b", "id" -> 3), 0, new StringBuilder(), List.empty[(Int, ParameterValue)]) must beSuccessfulTry.like {
+                case prepared2 =>
+                  prepared1._1 aka "sql" must_== prepared2._1 and (
+                    prepared2._2 aka "parameters #2" must_== (
+                      List[(Int, ParameterValue)](0 -> "a", 1 -> "b", 2 -> 3)))
+              }
+            } and {
+              Sql.prepareQuery(stmt3.tokens, stmt3.names, Map[String, ParameterValue]("cs" -> List("a", "b"), "id" -> 3), 0, new StringBuilder(), List.empty[(Int, ParameterValue)]) must beSuccessfulTry.like {
+                case prepared3 =>
+                  prepared3._1 aka "sql" must_== prepared1._1 and (
+                    prepared3._2 aka "parameters #3" must_== prepared1._2)
+              }
+            }
       }
     }
 
-    "return no prepared query" in {
-      TokenizedStatement.rewrite(TokenizedStatement(List(TokenGroup(
-        List(StringToken("SELECT * FROM Test WHERE id = ?")), None)), Nil),
-        "x") aka "rewrite" must beFailedTry
-    }
-  }
-
-  "Tokenized statement" should {
     val stmt = TokenizedStatement(List(TokenGroup(List(StringToken("SELECT * FROM name LIKE "), StringToken("'"), PercentToken, StringToken("strange"), StringToken("'"), StringToken(" AND id = ")), Some("id"))), List("id"))
 
-    "not be prepared as SQL if there is some placeholder not rewritten" in {
-      TokenizedStatement.toSql(stmt) must beFailedTry
+    "not be prepared as SQL if there is missing parameter" in {
+      Sql.prepareQuery(stmt.tokens, stmt.names, Map.empty[String, ParameterValue], 0, new StringBuilder(), List.empty[(Int, ParameterValue)]) must beFailedTry.
+        like {
+          case err: Sql.MissingParameter =>
+            err.getMessage must startWith(
+              """Missing parameter value after: "SELECT""")
+        }
     }
 
     "properly written as prepared SQL" in {
-      TokenizedStatement.rewrite(stmt, "?") must beSuccessfulTry.like {
-        case rw =>
-          TokenizedStatement.toSql(rw) must beSuccessfulTry("SELECT * FROM name LIKE '%strange' AND id = ?")
+      Sql.prepareQuery(stmt.tokens, stmt.names, Map[String, ParameterValue]("id" -> "foo"), 0, new StringBuilder(), List.empty[(Int, ParameterValue)]) must beSuccessfulTry.like {
+        case (sql, (0, pv) :: Nil) =>
+          sql must_== "SELECT * FROM name LIKE '%strange' AND id = ?" and (
+            pv must_== ParameterValue.toParameterValue("foo"))
       }
     }
   }
-   */
 
   "String interpolation" should {
+    "be successfully prepared" in {
+      val hell = "sinki"
+      val query = SQL"""
+         SELECT * FROM (SELECT 'Hello' AS COL1, 'World' AS COL2) AS MY_TABLE WHERE COL1 LIKE $hell + '%'
+      """
+
+      query.sql.stmt aka "tokenized" must_== TokenizedStatement(List(
+        TokenGroup(List(StringToken("""
+         SELECT * FROM (SELECT 'Hello' AS COL1, 'World' AS COL2) AS MY_TABLE WHERE COL1 LIKE """)), Some("_0")),
+        TokenGroup(List(StringToken(""" + '%'
+      """)), None)), List("_0")) and {
+        query.sql.paramsInitialOrder aka "parameter names" must_== List("_0")
+      } and {
+        query.params aka "parameters" must_== Map[String, ParameterValue](
+          "_0" -> "sinki")
+      }
+    }
+
     "handle values as '#' escaped part in statement or SQL parameters" in {
       val cmd = "SELECT"
       val clause = "FROM"

--- a/core/src/test/scala/anorm/TupleFlattenerSpec.scala
+++ b/core/src/test/scala/anorm/TupleFlattenerSpec.scala
@@ -6,7 +6,7 @@ import acolyte.jdbc.RowLists._
 import acolyte.jdbc.AcolyteDSL.withQueryResult
 import acolyte.jdbc.Implicits._
 
-object TupleFlattenerSpec extends org.specs2.mutable.Specification {
+class TupleFlattenerSpec extends org.specs2.mutable.Specification {
   "Tuple flattener" title
 
   "Raw tuple-like" should {

--- a/iteratee/src/test/scala/anorm/IterateeSpec.scala
+++ b/iteratee/src/test/scala/anorm/IterateeSpec.scala
@@ -1,4 +1,7 @@
 import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import org.specs2.concurrent.{ ExecutionEnv => EE }
 
 import play.api.libs.iteratee.Iteratee
 
@@ -8,15 +11,16 @@ import acolyte.jdbc.AcolyteDSL.withQueryResult
 import acolyte.jdbc.RowLists.stringList
 import acolyte.jdbc.Implicits._
 
-object IterateeSpec extends org.specs2.mutable.Specification {
+class IterateeSpec extends org.specs2.mutable.Specification {
   "Play Iteratee" title
 
   "Iteratees" should {
-    "broadcast the streaming result" in (
-      withQueryResult(stringList :+ "A" :+ "B" :+ "C")) { implicit con =>
+    "broadcast the streaming result" in { implicit ee: EE =>
+      withQueryResult(stringList :+ "A" :+ "B" :+ "C") { implicit con =>
         Iteratees.from(SQL"SELECT * FROM Test", SqlParser.scalar[String]).
           run(Iteratee.getChunks[String]) must beEqualTo(List("A", "B", "C")).
-          await(1000)
+          await(0, 5.second)
       }
+    }
   }
 }


### PR DESCRIPTION
### Anorm Version (2.5.x / etc)
2.5.1

### Operating System (Ubuntu 15.10 / MacOS 10.10 / Windows 10)
windows 10
### JDK (Oracle 1.8.0_72, OpenJDK 1.8.x, Azul Zing)
jdk 1.8_91 x64
### Library Dependencies
com.microsoft.sqlserver.jdbc.SQLServerDriver
### Expected Behavior
```
val hell = "Hell"
val data2 = DBMS.withConnection( implicit conn =>
      SQL"""
         SELECT * FROM (SELECT 'Hello' AS COL1, 'World' AS COL2) AS MY_TABLE WHERE COL1 LIKE $hell + '%'
      """.as(SqlParser.str(1).single)
    )
```
run without exception
### Actual Behavior

[RuntimeException: No parameter value for placeholder: 2]
![image](https://cloud.githubusercontent.com/assets/7894760/15986977/47c009d8-3053-11e6-95b3-c0ab00a3b85b.png)

### Workaround
```
val hell = "Hell" + "%"
val data2 = DBMS.withConnection( implicit conn =>
      SQL"""
         SELECT * FROM (SELECT 'Hello' AS COL1, 'World' AS COL2) AS MY_TABLE WHERE COL1 LIKE $hell
      """.as(SqlParser.str(1).single)
    )
```


