### PR TITLE
removed second ^ from simpleExpr regex

### DIFF
--- a/core/src/main/scala/anorm/SqlStatementParser.scala
+++ b/core/src/main/scala/anorm/SqlStatementParser.scala
@@ -30,7 +30,7 @@ object SqlStatementParser extends JavaTokenParsers {
     "\\" ~> ".{1}".r ^^ { StringToken(_) }
 
   private val simpleExpr: Parser[StringToken] =
-    """[^%^{\\]+""".r ^^ { StringToken(_) }
+    """[^%{\\]+""".r ^^ { StringToken(_) }
 
   private val instr: Parser[TokenizedStatement] = {
     @inline def normalize(t: StatementToken): Option[TokenGroup] = t match {

--- a/core/src/test/scala/anorm/StatementParserSpec.scala
+++ b/core/src/test/scala/anorm/StatementParserSpec.scala
@@ -15,11 +15,11 @@ class StatementParserSpec extends org.specs2.mutable.Specification {
   "Statement" should {
     "be parsed with 'name' and 'cat' parameters and support multiple lines" in {
       SqlStatementParser.parse("""
-        SELECT * FROM schema.table
+        SELECT *, '^foo' as foo, 2^3 as bar FROM schema.table
         -- Foo's comment
         WHERE (name = {name} AND category = {cat}) OR id = ?
       """) aka "updated statement and parameters" must beSuccessfulTry(
-        TokenizedStatement(List(TokenGroup(List(StringToken("""SELECT * FROM schema.table
+        TokenizedStatement(List(TokenGroup(List(StringToken("""SELECT *, '^foo' as foo, 2^3 as bar FROM schema.table
         -- Foo's comment
         WHERE (name = """)), Some("name")), TokenGroup(List(StringToken(" AND category = ")), Some("cat")), TokenGroup(List(StringToken(""") OR id = ?
       """)), None)), List("name", "cat")))


### PR DESCRIPTION
## Fixes

Fixes #150  

## Purpose

Removes the second erroneous ^ symbol in the simple expr regex that causes the statement parser to fail.

## Background Context

It is not possible to run a query with a ^ (carat) character (often found in regexps) because of a bug in the statement parser that causes parsing to stop when a ^ is encountered, resulting in only part of the requested sql being sent to jdbc.  This implements @mechkg suggested fix.  
