### PR TITLE
Add missing placeholder name in exception

### DIFF
--- a/core/src/main/scala/anorm/Anorm.scala
+++ b/core/src/main/scala/anorm/Anorm.scala
@@ -211,9 +211,9 @@ object Sql { // TODO: Rename to SQL
   }
 
   @SuppressWarnings(Array("IncorrectlyNamedExceptions"))
-  final class MissingParameter(after: String)
+  final class MissingParameter(after: String, placeholder: String)
     extends java.util.NoSuchElementException(
-      s"Missing parameter value after: $after") with NoStackTrace {}
+      s"Missing parameter value for '$placeholder' after: $after") with NoStackTrace {}
 
   object NoMorePlaceholder extends Exception("No more placeholder")
     with NoStackTrace {}
@@ -231,8 +231,8 @@ object Sql { // TODO: Rename to SQL
         query(tok.tail, ns.tail, ps, i + c, prepared, (i, p) :: vs)
       }
 
-      case (Some(TokenGroup(pr, Some(_))), _) =>
-        Failure(new MissingParameter(pr mkString ", "))
+      case (Some(TokenGroup(pr, Some(placeholder))), _) =>
+        Failure(new MissingParameter(pr mkString ", ", placeholder))
 
       case (Some(TokenGroup(pr, None)), _) =>
         query(tok.tail, ns, ps, i, toSql(pr, buf), vs)

--- a/core/src/main/scala/anorm/Anorm.scala
+++ b/core/src/main/scala/anorm/Anorm.scala
@@ -213,7 +213,10 @@ object Sql { // TODO: Rename to SQL
   @SuppressWarnings(Array("IncorrectlyNamedExceptions"))
   final class MissingParameter(after: String, placeholder: String)
     extends java.util.NoSuchElementException(
-      s"Missing parameter value for '$placeholder' after: $after") with NoStackTrace {}
+      s"Missing parameter value for '$placeholder' after: $after") with NoStackTrace {
+    @deprecated("Create this exception while supplying the missing placeholder value", "2.6.1")
+    def this(after: String) = this(after, "")
+  }
 
   object NoMorePlaceholder extends Exception("No more placeholder")
     with NoStackTrace {}

--- a/core/src/main/scala/anorm/Anorm.scala
+++ b/core/src/main/scala/anorm/Anorm.scala
@@ -215,7 +215,7 @@ object Sql { // TODO: Rename to SQL
     extends java.util.NoSuchElementException(
       s"Missing parameter value for '$placeholder' after: $after") with NoStackTrace {
     @deprecated("Create this exception while supplying the missing placeholder value", "2.6.1")
-    def this(after: String) = this(after, "")
+    def this(after: String) = this(after, "<unknown>")
   }
 
   object NoMorePlaceholder extends Exception("No more placeholder")

--- a/core/src/test/scala/anorm/StatementParserSpec.scala
+++ b/core/src/test/scala/anorm/StatementParserSpec.scala
@@ -106,7 +106,7 @@ class StatementParserSpec extends org.specs2.mutable.Specification {
         like {
           case err: Sql.MissingParameter =>
             err.getMessage must startWith(
-              """Missing parameter value after: "SELECT""")
+              """Missing parameter value for 'id' after: "SELECT""")
         }
     }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

Add a more helpful message in case of missing parameter in sql queries

## Background Context

When submiting a complex and long sql query with multiple parameters it's hard to know which parameter is missing. Here we add the name of the missing parameter in the exception to help the user.

For instance with a query:
```scala
SQL("SELECT * FROM test WHERE foo = {foo} AND bar = {bar}")
  .on("foo" -> 42)
  .execute()
```

We now get the message `Missing parameter value for 'bar' after: "AND bar = "`