### PR TITLE
'column not found' vs 'null value found'

### DIFF
--- a/core/src/main/scala/anorm/SqlParser.scala
+++ b/core/src/main/scala/anorm/SqlParser.scala
@@ -621,6 +621,19 @@ trait RowParser[+A] extends (Row => SqlResult[A]) { parent =>
     }
   }
 
+  /**
+   * Returns a row parser for nullable column,
+   * that will turn null into None.
+   */
+  def nullable: RowParser[Option[A]] = RowParser {
+    parent(_) match {
+      case Success(a) => Success(Some(a))
+      case Error(UnexpectedNullableFound(_)) =>
+        Success(None)
+      case e @ Error(_) => e
+    }
+  }
+
   /** Alias for [[flatMap]] */
   def >>[B](f: A => RowParser[B]): RowParser[B] = flatMap(f)
 


### PR DESCRIPTION


# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

I recently came across some unexpected behavior for nullable columns with the `?` operator of `RowParser`. It accepts non-existent columns and returns `None` as a result. I expected it to throw an exception because it could never return a value for this query. 

Changing the behavior of the `?` would introduce a breaking change of the API. So I added a new method on `RowParser` to explicitly handle null values in the result set.

## Background Context

The current behavior of the `?` can easily create bugs. For example a simple typo in the column name will stay undetected in all negative tests and will only be detected in a positive test. Using the new `nullable` operator instead will show this typo on the first execution of the query.


## References

