### PR TITLE
prefer VMs over Containers in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 scala:
 - 2.12.7
 - 2.11.12
-sudo: false
+sudo: required
 cache:
   directories:
   - $HOME/.ivy2


### PR DESCRIPTION
https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517
