### PR TITLE
Explain support is community driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ To run the documentation server, run:
 To test the documentation code samples, run:
 
     sbt docs/test
+
+## Support
+
+The Play Mailer library is *[Community Driven][]*.
+
+[Community Driven]: https://developer.lightbend.com/docs/reactive-platform/2.0/support-terminology/index.html#community-driven

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ To test the documentation code samples, run:
 
 ## Support
 
-The Play Mailer library is *[Community Driven][]*.
+The Anorm library is *[Community Driven][]*.
 
 [Community Driven]: https://developer.lightbend.com/docs/reactive-platform/2.0/support-terminology/index.html#community-driven


### PR DESCRIPTION
## Purpose

Make it clear that support for Anorm is community driven.
