### PR TITLE
Setup sbt-dynver

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,5 @@ addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.9")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,35 @@
-version in ThisBuild := "2.6.5-SNAPSHOT"
+dynverVTagPrefix in ThisBuild := false
+
+version in ThisBuild := {
+  val Stable = """([0-9]+)\.([0-9]+)\.([0-9]+)""".r
+
+  (dynverGitDescribeOutput in ThisBuild).value match {
+    case Some(descr) => {
+      if ((isSnapshot in ThisBuild).value) {
+        (previousStableVersion in ThisBuild).value match {
+          case Some(previousVer) => {
+            val current = (for {
+              Seq(maj, min, patch) <- Stable.unapplySeq(previousVer)
+              nextPatch <- scala.util.Try(patch.toInt).map(_ + 1).toOption
+            } yield {
+              val suffix = descr.commitSuffix.sha
+              s"${maj}.${min}.${nextPatch}-${suffix}-SNAPSHOT"
+            }).getOrElse {
+              sys.error("Fails to determine qualified snapshot version")
+            }
+
+            current
+          }
+
+          case _ =>
+            sys.error("Fails to determine previous stable version")
+        }
+      } else {
+        descr.ref.value.drop(1) // without 'v' prefix
+      }
+    }
+
+    case _ =>
+      sys.error("Fails to resolve Git information")
+  }
+}


### PR DESCRIPTION
When dev is ongoing (last commit is not tagged as release):

```
sbt:anorm-parent> show version
[info] anorm-iteratee / version
[info] 	2.6.5-61642c58-SNAPSHOT
[info] anorm-postgres / version
[info] 	2.6.5-61642c58-SNAPSHOT
[info] anorm-core / version
[info] 	2.6.5-61642c58-SNAPSHOT
[info] anorm-akka / version
[info] 	2.6.5-61642c58-SNAPSHOT
[info] anorm-tokenizer / version
[info] 	2.6.5-61642c58-SNAPSHOT
[info] version
[info] 	2.6.5-61642c58-SNAPSHOT
```

If on version tag:

```
cchantep@leto ~/Projects/anorm $ git tag -a 2.6.5 -m "Test"

cchantep@leto ~/Projects/anorm $ sbt

[info] Loading settings for project global-plugins from scala-steward.sbt ...
[info] Loading global plugins from /Users/cchantep/.sbt/1.0/plugins
[info] Loading settings for project anorm-build from plugins.sbt ...
[info] Loading project definition from /Users/cchantep/Projects/anorm/project
[info] Loading settings for project anorm-parent from version.sbt,build.sbt ...
[info] Set current project to anorm-parent (in build file:/Users/cchantep/Projects/anorm/)
sbt:anorm-parent> show version
[info] anorm-iteratee / version
[info] 	2.6.5
[info] anorm-postgres / version
[info] 	2.6.5
[info] anorm-core / version
[info] 	2.6.5
[info] anorm-akka / version
[info] 	2.6.5
[info] anorm-tokenizer / version
[info] 	2.6.5
[info] version
[info] 	2.6.5
```