### PR TITLE
FIX - Issue 325 - Column[Instant] loose nano seconds precision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 logs
 project/project
+.bsp

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{
 ThisBuild / scalaVersion := "2.12.12"
 
 ThisBuild / crossScalaVersions := Seq(
-  "2.11.12", (scalaVersion in ThisBuild).value, "2.13.3")
+  "2.11.12", (scalaVersion in ThisBuild).value, "2.13.4")
 
 // Scalafix
 inThisBuild(

--- a/core/src/main/scala/anorm/Column.scala
+++ b/core/src/main/scala/anorm/Column.scala
@@ -713,10 +713,11 @@ sealed trait JavaTimeColumn {
   implicit val columnToInstant: Column[Instant] = nonNull { (value, meta) =>
     val MetaDataItem(qualified, _, _) = meta
     value match {
+      case ts: java.sql.Timestamp => Ts(ts)(_.toInstant)
       case date: java.util.Date => Right(Instant ofEpochMilli date.getTime)
       case time: Long => Right(Instant ofEpochMilli time)
-      case TimestampWrapper1(ts) => Ts(ts)(Instant ofEpochMilli _.getTime)
-      case TimestampWrapper2(ts) => Ts(ts)(Instant ofEpochMilli _.getTime)
+      case TimestampWrapper1(ts) => Ts(ts)(_.toInstant)
+      case TimestampWrapper2(ts) => Ts(ts)(_.toInstant)
       case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${className(value)} to Java8 Instant for column $qualified"))
     }
   }

--- a/core/src/test/scala/anorm/JavaTimeSpec.scala
+++ b/core/src/test/scala/anorm/JavaTimeSpec.scala
@@ -1,5 +1,6 @@
 package anorm
 
+import java.sql.Timestamp
 import java.time.{ Instant, LocalDate, LocalDateTime, ZoneId, ZonedDateTime }
 
 import acolyte.jdbc.AcolyteDSL._
@@ -34,6 +35,16 @@ class JavaTimeColumnSpec extends Specification {
         SQL("SELECT ts").as(scalar[Instant].single).
           aka("parsed instant") must_=== instant
       }
+
+    "be parsed from timestamp with nano precision" in {
+      val instantWithNanoPrecision = Instant.parse("2021-01-06T08:45:26.441477Z")
+
+      withQueryResult(
+        timestampList :+ Timestamp.from(instantWithNanoPrecision)) { implicit con =>
+          SQL("SELECT ts").as(scalar[Instant].single).
+            aka("parsed instant") must_=== instantWithNanoPrecision
+        }
+    }
 
     "be parsed from numeric time" in withQueryResult(longList :+ time) {
       implicit con =>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)? yes
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)? yes
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)? yes
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)? yes
* [x] Have you added copyright headers to new files? not relevant
* [x] Have you checked that both Scala and Java APIs are updated? no api changes
* [x] Have you updated the documentation for both Scala and Java sections? no changes
* [x] Have you added tests for any changed functionality? yes

## Fixes

Fixes [#325](https://github.com/playframework/anorm/issues/325)

## Purpose

Fix the default instance of **Column[Instant]** in the **JavaTimeColumn** trait, so we don't loose the nano second precision during the SQL result reads.

## Background Context

When reading an SQL result, **TIMESTAMP[TZ]** from database is mapped on the **java.sql.Timestamp** type. Therefore, the **Column[Instant]** should be able to transform a given **java.sql.Timestamp** into an **java.time.Instant**

As **java.sql.Timestamp** inherits **java.util.Date**, the first branch of following pattern-matching will be selected

```scala
   value match {
      case date: java.util.Date => Right(Instant ofEpochMilli date.getTime)
      case time: Long => Right(Instant ofEpochMilli time)
      case TimestampWrapper1(ts) => Ts(ts)(Instant ofEpochMilli _.getTime)
      case TimestampWrapper2(ts) => Ts(ts)(Instant ofEpochMilli _.getTime)
      case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${className(value)} to Java8 Instant for column $qualified"))
    }
```

https://github.com/playframework/anorm/blob/master/core/src/main/scala/anorm/Column.scala#L715

The problem is that **java.util.Date** is precised at the miliseconds level, and not the nano seconds level. Dealing with a **java.sql.Timestamp** as as **java.util.Date** will loose this precision, as we can understand immediatly with the following code:
```scala
Instant ofEpochMilli date.getTime
```
(**getTime** returns EPOCH miliseconds, as explained in javadoc)

I wonder why the pattern-matching wasn't using directly the **java.sql.Timestamp** type? Maybe is there an hidden reason I couldn't understand?

Adding a line (in first position) with a pattern on **java.sql.Timestamp** seems to be ok, especially since **Timestamp** can be directly converted to **Instant** with the method **.toInstant**.

The 2 lines that matches **TimestampWrapper1** and **TimestampWrapper2** would loose in the same way, because it build the Instant using only the miliseconds.

I took this opportunty to use **ts.toInstant** here to, to avoid silent data loss behavior.

Actually, I'm not sure to understand when these **TimestampWrapper** become useful, but I might not have the full picture I my mind.

## References

The issue is explained in details here https://github.com/playframework/anorm/issues/325
