### PR TITLE
columnToLocalDateTime should accept LocalDateTime

### DIFF
--- a/core/src/test/scala/anorm/ColumnSpec.scala
+++ b/core/src/test/scala/anorm/ColumnSpec.scala
@@ -10,6 +10,7 @@ import java.net.{ URI, URL }
 
 import java.sql.{ Array => SqlArray }
 import javax.sql.rowset.serial.{ SerialBlob, SerialClob }
+import java.time.LocalDateTime
 
 import scala.util.Random
 
@@ -189,6 +190,13 @@ class ColumnSpec
     "be parsed from date" in withQueryResult(dateList :+ now) { implicit con =>
       SQL"SELECT d".as(scalar[Long].single).
         aka("parsed long") must_=== now.getTime
+    }
+
+    val localDateTimeNow = LocalDateTime.now()
+    val localDateTimeRow = rowList1(classOf[LocalDateTime])
+    "be parsed from LocalDateTime" in withQueryResult(localDateTimeRow :+ localDateTimeNow) { implicit con =>
+      SQL"SELECT d".as(scalar[LocalDateTime].single).
+        aka("parsed LocalDateTime") must_=== localDateTimeNow
     }
 
     "be parsed from a timestamp wrapper" in withQueryResult(


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [X] ~~Have you added copyright headers to new files?~~
* [X] ~~Have you checked that both Scala and Java APIs are updated?~~
* [X] ~~Have you updated the documentation for both Scala and Java sections?~~
* [X] Have you added tests for any changed functionality?

## Fixes

Fixes #329

## Purpose

The latest MySQL JDBC driver returns LocalDateTime instances for datetime columns, however the existing `Column[LocalDateTime]` definition does not support LocalDateTime objects in its pattern match.

## Background Context

I changed to the column definition so that it returns the LocalDateTime instance directly without first converting epoch millis and back again. Other than that, this change was fairly straight forward.
