### PR TITLE
add parentheses for lambda param

### DIFF
--- a/core/src/main/scala/anorm/Column.scala
+++ b/core/src/main/scala/anorm/Column.scala
@@ -779,7 +779,7 @@ sealed trait JavaTimeColumn {
    * }}}
    */
   implicit val columnToLocalDate: Column[LocalDate] =
-    temporalColumn[LocalDate]({ ts: Long =>
+    temporalColumn[LocalDate]({ (ts: Long) =>
       LocalDateTime.ofInstant(
         Instant.ofEpochMilli(ts), ZoneId.systemDefault).toLocalDate
     }, "Java8 LocalDate")
@@ -800,7 +800,7 @@ sealed trait JavaTimeColumn {
    * }}}
    */
   implicit val columnToZonedDateTime: Column[ZonedDateTime] =
-    temporalColumn[ZonedDateTime]({ ts: Long =>
+    temporalColumn[ZonedDateTime]({ (ts: Long) =>
       ZonedDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneId.systemDefault)
     }, "Java8 ZonedDateTime")
 }

--- a/core/src/main/scala/anorm/macros/ToParameterListImpl.scala
+++ b/core/src/main/scala/anorm/macros/ToParameterListImpl.scala
@@ -73,7 +73,7 @@ private[anorm] object ToParameterListImpl {
 
     val debug: String => Unit = {
       if (debugEnabled) c.echo(c.enclosingPosition, _: String)
-      else { _: String => () }
+      else { (_: String) => () }
     }
 
     val compiledProj: Seq[ParameterProjection] = projection.map { expr =>

--- a/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
+++ b/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
@@ -47,7 +47,7 @@ object MacroParsers {
 
   // Generate a parser as following...
   val generated: RowParser[Family] =
-    SqlParser.str("classname").flatMap { discriminator: String =>
+    SqlParser.str("classname").flatMap { (discriminator: String) =>
       discriminator match {
         case "scalaguide.sql.MacroParsers.Bar" =>
           implicitly[RowParser[Bar]]


### PR DESCRIPTION


# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes



## Purpose

prepare Scala 3

```
scala> Option(1).map{ a => a }
val res0: Option[Int] = Some(1)

scala> Option(1).map{ a: Int => a }
1 |Option(1).map{ a: Int => a }
  |                      ^
  |parentheses are required around the parameter of a lambda
  |This construct can be rewritten automatically under -rewrite -source 3.0-migration.
```

## Background Context


## References
