### PR TITLE
fix warning in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ val armShading = Seq(
   libraryDependencies += "com.jsuereth" %% "scala-arm" % "2.1-SNAPSHOT",
   assembly / test := {},
   assembly / assemblyOption ~= {
-    _.copy(includeScala = false) // java libraries shouldn't include scala
+    _.withIncludeScala(false) // java libraries shouldn't include scala
   },
   (assembly / assemblyJarName) := {
     CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION


# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes warning in build.sbt

## Purpose

## Background Context

```
/home/travis/build/playframework/anorm/build.sbt:54: warning: method copy in class AssemblyOption is deprecated (since 1.0.0): copy method is deprecated; use withIncludeBin(...) etc
    _.copy(includeScala = false) // java libraries shouldn't include scala
      ^
```

## References

https://github.com/sbt/sbt-assembly/pull/433