### PR TITLE
FIX - Issue #408 - Column[ZonedDateTime] loses nanoseconds precision

### DIFF
--- a/core/src/test/scala/anorm/JavaTimeSpec.scala
+++ b/core/src/test/scala/anorm/JavaTimeSpec.scala
@@ -188,6 +188,15 @@ class JavaTimeColumnSpec extends Specification {
           aka("parsed zoned date/time") must_=== date
       }
 
+    "be parsed from timestamp with nano precision" in {
+      val instantWithNanoPrecision = Instant.parse("2021-01-06T08:45:26.441477Z")
+      withQueryResult(
+        timestampList :+ java.sql.Timestamp.from(instantWithNanoPrecision)) { implicit con =>
+          SQL("SELECT ts").as(scalar[ZonedDateTime].single).
+            aka("parsed zoned date/time") must_=== ZonedDateTime.ofInstant(instantWithNanoPrecision, ZoneId.systemDefault)
+        }
+    }
+
     "be parsed from numeric time" in withQueryResult(longList :+ time) {
       implicit con =>
         SQL("SELECT time").as(scalar[ZonedDateTime].single).


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [X] Have you added copyright headers to new files?
* [X] Have you checked that both Scala and Java APIs are updated?
* [X] Have you updated the documentation for both Scala and Java sections?
* [X] Have you added tests for any changed functionality?

## Fixes

Fixes #408

## Purpose

Fix the default instance of `Column[ZonedDateTime]` in the `JavaTimeColumn` trait, so it doesn't lose the nanosecond precision during the SQL result reads.

## Background Context

When reading an SQL result, `TIMESTAMP[TZ]` from database is mapped on the `java.sql.Timestamp` type. This type extends from `java.util.Date` but has a nanosecond precision. In current implementation the conversion is handle by `temporalValueTo` function:
```scala
  private def temporalValueTo[T](epoch: Long => T, description: String)(value: Any, meta: MetaDataItem): Either[SqlRequestError, T] = {
    val MetaDataItem(qualified, _, _) = meta
    value match {
      case date: java.util.Date => Right(epoch(date.getTime)) // Timestamp conversion
      case time: Long => Right(epoch(time))
      case TimestampWrapper1(ts) => Ts(ts)(t => epoch(t.getTime))
      case TimestampWrapper2(ts) => Ts(ts)(t => epoch(t.getTime))
      case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${className(value)} to $description for column $qualified"))
    }
  }
```
`java.sql.Timestamp` is matched as a `java.util.Date` and `date.getTime` only provides milliseconds.

There was already a fix for the `Instant` type:

```scala
  implicit val columnToInstant: Column[Instant] = nonNull { (value, meta) =>
    val MetaDataItem(qualified, _, _) = meta

    value match {
      case date: LocalDateTime => Right(date.toInstant(ZoneOffset.UTC))
      case ts: java.sql.Timestamp => Ts(ts)(_.toInstant) //Timestamp conversion with nanoseconds
      case date: java.util.Date => Right(Instant ofEpochMilli date.getTime)
      case time: Long => Right(Instant ofEpochMilli time)
      case TimestampWrapper1(ts) => Ts(ts)(_.toInstant)
      case TimestampWrapper2(ts) => Ts(ts)(_.toInstant)
      case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${className(value)} to Java8 Instant for column $qualified"))
    }
  }
```

My suggestion is to reuse this fix and to use `Instant` as the intermediate type for date/time conversion instead of `Long`.
So that all conversion will have to provide a function `Instant => T` when it was `Long => T`.


## References

`Column[Instant]`  fix  #325 and PR #326 
