### PR TITLE
Fix SQL corresponding type for Java long

### DIFF
--- a/core/src/main/scala/anorm/ParameterMetaData.scala
+++ b/core/src/main/scala/anorm/ParameterMetaData.scala
@@ -130,13 +130,13 @@ object ParameterMetaData extends JavaTimeParameterMetaData {
   }
 
   implicit object LongParameterMetaData extends ParameterMetaData[Long] {
-    val sqlType  = BigIntParameterMetaData.sqlType
-    val jdbcType = BigIntParameterMetaData.jdbcType
+    val sqlType  = "BIGINT"
+    val jdbcType = Types.BIGINT
   }
 
   implicit object JLongParameterMetaData extends ParameterMetaData[JLong] {
-    val sqlType  = BigIntParameterMetaData.sqlType
-    val jdbcType = BigIntParameterMetaData.jdbcType
+    val sqlType  = LongParameterMetaData.sqlType
+    val jdbcType = LongParameterMetaData.jdbcType
   }
 
   /** Decimal (big decimal) parameter meta data */


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [X] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #478

## Purpose

Fixes `ParameterMetaData` for `Long` type. `Long` should be represented by the SQL `BIGINT` type.

## Background Context

I saw this behavior because it broke an optimized query.

## References

None