### PR TITLE
Explicitly set sonatypeProfileName to "org.playframework"

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,8 +1,8 @@
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
-
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
+import xerial.sbt.Sonatype.autoImport._
 
 object Common extends AutoPlugin {
   import com.typesafe.tools.mima.core._
@@ -13,9 +13,10 @@ object Common extends AutoPlugin {
   val previousVersion = "2.6.10"
 
   override def projectSettings = Seq(
-    organization       := "org.playframework.anorm",
-    scalaVersion       := "2.12.16",
-    crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.8", "3.1.3"),
+    organization        := "org.playframework.anorm",
+    sonatypeProfileName := "org.playframework",
+    scalaVersion        := "2.12.16",
+    crossScalaVersions  := Seq("2.11.12", scalaVersion.value, "2.13.8", "3.1.3"),
     (Compile / unmanagedSourceDirectories) ++= {
       val sv = scalaVersion.value
 


### PR DESCRIPTION
Fixes #485
Finally I got it, this is the correct profile name we have to use:

![image](https://user-images.githubusercontent.com/644927/193059686-758ab9d4-e0ee-46d7-a71b-a2a09d9fb701.png)

And with with profile name we have access to all groupIds of  `org.playframework.*`
