### PR TITLE
Remove .jvmopts not needed anymore

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,0 @@
--Xss2M
--XX:+CMSClassUnloadingEnabled
--XX:ReservedCodeCacheSize=192m


### PR DESCRIPTION
Was added for Travis in 822722ffd7f3367777c859ab2e476f5f50f30f88, but now we use GitHub actions