### PR TITLE
Prepare anorm-docs project for Scala 3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,7 +27,7 @@ jobs:
     name: Docs
     uses: playframework/.github/.github/workflows/cmd.yml@v4
     with:
-      java: 11
+      java: 11, 8
       scala: 2.11.x, 2.12.x, 2.13.x, 3.x
       cmd: sbt ++$MATRIX_SCALA docs/test
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,8 +27,8 @@ jobs:
     name: Docs
     uses: playframework/.github/.github/workflows/cmd.yml@v4
     with:
-      java: 11, 8
-      scala: 2.11.x, 2.12.x, 2.13.x # TODO: 3.x (other play modules not ok)
+      java: 11
+      scala: 2.11.x, 2.12.x, 2.13.x, 3.x
       cmd: sbt ++$MATRIX_SCALA docs/test
 
   tests:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,11 +23,19 @@ jobs:
     name: Binary Compatibility
     uses: playframework/.github/.github/workflows/binary-check.yml@v4
 
-  check-docs:
+  check-docs-8:
+    name: Docs Java 8
+    uses: playframework/.github/.github/workflows/cmd.yml@v4
+    with:
+      java: 8
+      scala: 2.11.x, 2.12.x, 2.13.x
+      cmd: sbt ++$MATRIX_SCALA docs/test
+
+  check-docs-11:
     name: Docs
     uses: playframework/.github/.github/workflows/cmd.yml@v4
     with:
-      java: 11, 8
+      java: 11
       scala: 2.11.x, 2.12.x, 2.13.x, 3.x
       cmd: sbt ++$MATRIX_SCALA docs/test
 

--- a/akka/src/main/scala/anorm/AkkaStream.scala
+++ b/akka/src/main/scala/anorm/AkkaStream.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
 import scala.concurrent.{ Future, Promise }
 
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Source }
+import akka.stream.scaladsl.Source
 
 /**
  * Anorm companion for the [[http://doc.akka.io/docs/akka/2.4.4/scala/stream/]].
@@ -70,7 +70,7 @@ object AkkaStream {
   def source[T](sql: => Sql, parser: RowParser[T])(implicit
       @deprecated("No longer required (will be removed)", "2.5.4") m: Materializer,
       con: Connection
-  ): Source[T, Future[Int]] = source[T](sql, parser, ColumnAliaser.empty)
+  ): Source[T, Future[Int]] = Source.fromGraph(new ResultSource[T](con, sql, ColumnAliaser.empty, parser))
 
   /**
    * Returns the result rows from the `sql` query as an enumerator.
@@ -84,9 +84,9 @@ object AkkaStream {
    * @param connection $connectionParam
    */
   def source(sql: => Sql, as: ColumnAliaser)(implicit
-      m: Materializer,
-      connnection: Connection
-  ): Source[Row, Future[Int]] = source(sql, RowParser.successful, as)
+      @deprecated("No longer required (will be removed)", "2.7.1") m: Materializer,
+      @deprecatedName(Symbol("connnection")) con: Connection
+  ): Source[Row, Future[Int]] = Source.fromGraph(new ResultSource[Row](con, sql, as, RowParser.successful))
 
   /**
    * Returns the result rows from the `sql` query as an enumerator.

--- a/build.sbt
+++ b/build.sbt
@@ -402,7 +402,7 @@ lazy val `anorm-pekko` = (project in file("pekko"))
 lazy val pgVer = sys.env.get("POSTGRES_VERSION").getOrElse("42.7.1")
 
 val playVer = Def.setting[String] {
-  if (scalaBinaryVersion.value == "2.13" || scalaBinaryVersion.value == "3") "2.9.0-M4"
+  if (scalaBinaryVersion.value == "2.13" || scalaBinaryVersion.value == "3") "2.9.2"
   else "2.6.14"
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -402,7 +402,7 @@ lazy val `anorm-pekko` = (project in file("pekko"))
 lazy val pgVer = sys.env.get("POSTGRES_VERSION").getOrElse("42.7.1")
 
 val playVer = Def.setting[String] {
-  if (scalaBinaryVersion.value == "2.13") "2.7.3"
+  if (scalaBinaryVersion.value == "2.13" || scalaBinaryVersion.value == "3") "2.7.3"
   else "2.6.14"
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -423,8 +423,7 @@ lazy val `anorm-postgres` = (project in file("postgres"))
       val v = scalaBinaryVersion.value
 
       val playJsonVer = {
-        if (v == "2.13") "2.9.2"
-        else if (v == "3") "2.10.1"
+        if (v == "2.13" || v == "3") "2.10.4"
         else "2.6.7"
       }
 

--- a/build.sbt
+++ b/build.sbt
@@ -402,7 +402,7 @@ lazy val `anorm-pekko` = (project in file("pekko"))
 lazy val pgVer = sys.env.get("POSTGRES_VERSION").getOrElse("42.7.1")
 
 val playVer = Def.setting[String] {
-  if (scalaBinaryVersion.value == "2.13" || scalaBinaryVersion.value == "3") "2.7.3"
+  if (scalaBinaryVersion.value == "2.13" || scalaBinaryVersion.value == "3") "2.9.0-M4"
   else "2.6.14"
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ inThisBuild(
   List(
     // scalaVersion := "2.13.3",
     semanticdbEnabled := true,
-    semanticdbVersion := scalafixSemanticdb.revision
+    semanticdbVersion := scalafixSemanticdb.revision,
   )
 )
 
@@ -22,17 +22,25 @@ val specs2Test = Seq(
 ).map("org.specs2" %% _ % "4.10.6" % Test cross (CrossVersion.for3Use2_13))
   .map(_.exclude("org.scala-lang.modules", "*"))
 
-val common = Seq(
-  scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8") ++
-    (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 13)) => Seq("-Xsource:3", "-Xmigration")
-      case _             => Seq.empty
-    }),
-  javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
-)
+lazy val acolyte = "org.eu.acolyte" %% "jdbc-scala" % "1.2.9" % Test
 
-lazy val acolyteVersion = "1.2.9"
-lazy val acolyte        = "org.eu.acolyte" %% "jdbc-scala" % acolyteVersion % Test
+// Licensing
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern.commentBetween
+import de.heikoseeberger.sbtheader.{ CommentStyle, FileType, HeaderPlugin, LineCommentCreator }
+
+val licensing = Seq(
+  headerLicense := Some(
+    HeaderLicense.Custom(
+      "Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>"
+    )
+  ),
+  headerMappings ++= Map(
+    FileType("sbt")        -> HeaderCommentStyle.cppStyleLineComment,
+    FileType("properties") -> HeaderCommentStyle.hashLineComment,
+    FileType.xml           -> HeaderCommentStyle.xmlStyleBlockComment,
+    FileType("md")         -> CommentStyle(new LineCommentCreator("<!---", "-->"), commentBetween("<!---", "*", "-->"))
+  ),
+)
 
 ThisBuild / resolvers ++= Seq("Tatami Snapshots".at("https://raw.github.com/cchantep/tatami/master/snapshots"))
 
@@ -40,31 +48,23 @@ ThisBuild / mimaFailOnNoPrevious := false
 
 lazy val `anorm-tokenizer` = project
   .in(file("tokenizer"))
-  .settings(common)
   .settings(
-    mimaPreviousArtifacts := {
-      if (scalaBinaryVersion.value == "3") {
-        Set.empty
-      } else {
-        mimaPreviousArtifacts.value
-      }
-    },
-    scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") {
-        Seq.empty
-      } else {
-        Seq(
-          "-P:silencer:globalFilters=type Seq in package scala has changed semantics in version 2.13.0",
-        )
+    Seq(
+      mimaPreviousArtifacts := {
+        if (scalaBinaryVersion.value == "3") {
+          Set.empty
+        } else {
+          mimaPreviousArtifacts.value
+        }
       },
-    },
-    libraryDependencies += {
-      if (scalaBinaryVersion.value == "3") {
-        "org.scala-lang" %% "scala3-compiler" % scalaVersion.value % Provided
-      } else {
-        "org.scala-lang" % "scala-reflect" % scalaVersion.value
+      libraryDependencies += {
+        if (scalaBinaryVersion.value == "3") {
+          "org.scala-lang" %% "scala3-compiler" % scalaVersion.value % Provided
+        } else {
+          "org.scala-lang" % "scala-reflect" % scalaVersion.value
+        }
       }
-    }
+    ) ++ licensing
   )
 
 // ---
@@ -138,7 +138,6 @@ lazy val xmlVer = Def.setting[String] {
 
 lazy val `anorm-core` = project
   .in(file("core"))
-  .settings(common)
   .settings(
     Seq(
       name := "anorm",
@@ -153,10 +152,17 @@ lazy val `anorm-core` = project
         }
       },
       scalacOptions ++= {
-        if (scalaBinaryVersion.value == "3") {
-          Seq.empty
+        val v = scalaBinaryVersion.value
+
+        if (v == "3") {
           Seq(
-            "-Wconf:cat=deprecation&msg=.*(reflectiveSelectableFromLangReflectiveCalls|DeprecatedSqlParser|missing .*ToSql).*:s"
+            "-Wconf:msg=.*deprecated\\ .*wildcard\\ arguments.*:s",
+            "-Wconf:msg=.*no\\ longer\\ supported\\ .*vararg\\ splices.*:s"
+          )
+        } else if (v == "2.13") {
+          Seq(
+            "-Wconf:msg=.*method\\ .*in\\ class\\ Parser.*:s",
+            "-Wconf:src=.*/Macro.scala&msg=local\\ val\\ \\$m.*:s"
           )
         } else {
           Seq(
@@ -232,41 +238,42 @@ lazy val `anorm-core` = project
         "com.h2database"          % "h2"                       % "2.2.224"    % Test,
         acolyte
       ) ++ specs2Test,
-    ) ++ armShading
+    ) ++ armShading ++ licensing
   )
   .dependsOn(`anorm-tokenizer`)
 
 lazy val `anorm-iteratee` = (project in file("iteratee"))
-  .settings(common)
   .settings(
-    sourceDirectory := {
-      val v = scalaBinaryVersion.value
+    Seq(
+      sourceDirectory := {
+        val v = scalaBinaryVersion.value
 
-      if (v == "3" || v == "2.13") new java.io.File("/no/sources")
-      else sourceDirectory.value
-    },
-    mimaPreviousArtifacts := {
-      val v = scalaBinaryVersion.value
+        if (v == "3" || v == "2.13") new java.io.File("/no/sources")
+        else sourceDirectory.value
+      },
+      mimaPreviousArtifacts := {
+        val v = scalaBinaryVersion.value
 
-      if (v == "3" || v == "2.13") Set.empty[ModuleID]
-      else Set(organization.value %% name.value % "2.6.10")
-    },
-    publish / skip := {
-      val v = scalaBinaryVersion.value
+        if (v == "3" || v == "2.13") Set.empty[ModuleID]
+        else Set(organization.value %% name.value % "2.6.10")
+      },
+      publish / skip := {
+        val v = scalaBinaryVersion.value
 
-      v == "3" || v == "2.13"
-    },
-    libraryDependencies ++= {
-      val v = scalaBinaryVersion.value
+        v == "3" || v == "2.13"
+      },
+      libraryDependencies ++= {
+        val v = scalaBinaryVersion.value
 
-      if (v == "3" || v == "2.13") Seq.empty[ModuleID]
-      else
-        Seq(
-          "com.typesafe.play"      %% "play-iteratees" % "2.6.1",
-          "org.scala-lang.modules" %% "scala-xml"      % xmlVer.value % Test,
-          acolyte
-        ) ++ specs2Test
-    }
+        if (v == "3" || v == "2.13") Seq.empty[ModuleID]
+        else
+          Seq(
+            "com.typesafe.play"      %% "play-iteratees" % "2.6.1",
+            "org.scala-lang.modules" %% "scala-xml"      % xmlVer.value % Test,
+            acolyte
+          ) ++ specs2Test
+      }
+    ) ++ licensing
   )
   .dependsOn(`anorm-core`)
 
@@ -283,50 +290,55 @@ lazy val akkaVer = Def.setting[String] {
 }
 
 lazy val `anorm-akka` = (project in file("akka"))
-  .settings(common)
   .settings(
-    mimaPreviousArtifacts := {
-      if (scalaBinaryVersion.value == "3") {
-        Set.empty
-      } else {
-        mimaPreviousArtifacts.value
-      }
-    },
-    libraryDependencies ++= Seq("akka-testkit", "akka-stream").map { m =>
-      ("com.typesafe.akka" %% m % akkaVer.value % Provided).exclude("org.scala-lang.modules", "*")
-    },
-    libraryDependencies ++= Seq(
-      acolyte,
-      "org.scala-lang.modules" %% "scala-xml"           % xmlVer.value  % Test,
-      ("com.typesafe.akka"     %% "akka-stream-testkit" % akkaVer.value % Test).exclude("org.scala-lang.modules", "*")
-    ) ++ specs2Test,
-    scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") {
-        Seq("-Wconf:cat=deprecation&msg=.*(onDownstreamFinish|ActorMaterializer).*:s")
-      } else {
-        Seq("-P:silencer:globalFilters=deprecated")
-      }
-    },
-    Test / unmanagedSourceDirectories += {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n < 13 =>
-          (Test / sourceDirectory).value / "scala-2.13-"
+    Seq(
+      mimaPreviousArtifacts := {
+        if (scalaBinaryVersion.value == "3") {
+          Set.empty
+        } else {
+          mimaPreviousArtifacts.value
+        }
+      },
+      libraryDependencies ++= Seq("akka-testkit", "akka-stream").map { m =>
+        ("com.typesafe.akka" %% m % akkaVer.value % Provided).exclude("org.scala-lang.modules", "*")
+      },
+      libraryDependencies ++= Seq(
+        acolyte,
+        "org.scala-lang.modules" %% "scala-xml"           % xmlVer.value  % Test,
+        ("com.typesafe.akka"     %% "akka-stream-testkit" % akkaVer.value % Test).exclude("org.scala-lang.modules", "*")
+      ) ++ specs2Test,
+      scalacOptions ++= {
+        val v = scalaBinaryVersion.value
 
-        case _ =>
-          (Test / sourceDirectory).value / "scala-2.13+"
+        if (v == "3" || v == "2.13") {
+          Seq("-Wconf:msg=.*(onDownstreamFinish|ActorMaterializer).*:s")
+        } else if (v != "2.13") {
+          Seq("-P:silencer:globalFilters=deprecated")
+        } else {
+          Seq.empty
+        }
+      },
+      Test / unmanagedSourceDirectories += {
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, n)) if n < 13 =>
+            (Test / sourceDirectory).value / "scala-2.13-"
 
+          case _ =>
+            (Test / sourceDirectory).value / "scala-2.13+"
+
+        }
+      },
+      Test / unmanagedSourceDirectories += {
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, 11)) =>
+            (Test / sourceDirectory).value / "scala-2.12-"
+
+          case _ =>
+            (Test / sourceDirectory).value / "scala-2.12+"
+
+        }
       }
-    },
-    Test / unmanagedSourceDirectories += {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 11)) =>
-          (Test / sourceDirectory).value / "scala-2.12-"
-
-        case _ =>
-          (Test / sourceDirectory).value / "scala-2.12+"
-
-      }
-    }
+    ) ++ licensing
   )
   .dependsOn(`anorm-core`)
 
@@ -339,61 +351,64 @@ lazy val pekkoEnabled = Def.setting[Boolean] {
 }
 
 lazy val `anorm-pekko` = (project in file("pekko"))
-  .settings(common)
   .settings(
-    mimaPreviousArtifacts := Set.empty,
-    sourceDirectory := {
-      if (!pekkoEnabled.value) new java.io.File("/no/sources")
-      else sourceDirectory.value
-    },
-    publishArtifact := pekkoEnabled.value,
-    publish := Def.taskDyn {
-      val ver = scalaBinaryVersion.value
-      val go  = publish.value
+    Seq(
+      mimaPreviousArtifacts := Set.empty,
+      sourceDirectory := {
+        if (!pekkoEnabled.value) new java.io.File("/no/sources")
+        else sourceDirectory.value
+      },
+      publishArtifact := pekkoEnabled.value,
+      publish := Def.taskDyn {
+        val ver = scalaBinaryVersion.value
+        val go  = publish.value
 
-      Def.task {
+        Def.task {
+          if (pekkoEnabled.value) {
+            go
+          }
+        }
+      }.value,
+      libraryDependencies ++= {
         if (pekkoEnabled.value) {
-          go
+          Seq("pekko-testkit", "pekko-stream").map { m =>
+            ("org.apache.pekko" %% m % pekkoVer.value % Provided).exclude("org.scala-lang.modules", "*")
+          }
+        } else {
+          Seq.empty
+        }
+      },
+      libraryDependencies ++= {
+        if (pekkoEnabled.value) {
+          Seq(
+            acolyte,
+            "org.scala-lang.modules" %% "scala-xml"            % xmlVer.value   % Test,
+            "org.apache.pekko"       %% "pekko-stream-testkit" % pekkoVer.value % Test
+          ) ++ specs2Test
+        } else {
+          Seq.empty
+        }
+      },
+      scalacOptions ++= {
+        val v = scalaBinaryVersion.value
+
+        if (v == "3" || v == "2.13") {
+          Seq("-Wconf:cat=deprecation&msg=.*(onDownstreamFinish|ActorMaterializer).*:s")
+        } else {
+          Seq("-P:silencer:globalFilters=deprecated")
+        }
+      },
+      Test / unmanagedSourceDirectories ++= {
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, n)) if n < 13 =>
+            Seq((Test / sourceDirectory).value / "scala-2.13-")
+
+          case _ =>
+            Seq((Test / sourceDirectory).value / "scala-2.13+")
+
         }
       }
-    }.value,
-    libraryDependencies ++= {
-      if (pekkoEnabled.value) {
-        Seq("pekko-testkit", "pekko-stream").map { m =>
-          ("org.apache.pekko" %% m % pekkoVer.value % Provided).exclude("org.scala-lang.modules", "*")
-        }
-      } else {
-        Seq.empty
-      }
-    },
-    libraryDependencies ++= {
-      if (pekkoEnabled.value) {
-        Seq(
-          acolyte,
-          "org.scala-lang.modules" %% "scala-xml"            % xmlVer.value   % Test,
-          "org.apache.pekko"       %% "pekko-stream-testkit" % pekkoVer.value % Test
-        ) ++ specs2Test
-      } else {
-        Seq.empty
-      }
-    },
-    scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") {
-        Seq("-Wconf:cat=deprecation&msg=.*(onDownstreamFinish|ActorMaterializer).*:s")
-      } else {
-        Seq("-P:silencer:globalFilters=deprecated")
-      }
-    },
-    Test / unmanagedSourceDirectories ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n < 13 =>
-          Seq((Test / sourceDirectory).value / "scala-2.13-")
-
-        case _ =>
-          Seq((Test / sourceDirectory).value / "scala-2.13+")
-
-      }
-    }
+    ) ++ licensing
   )
   .dependsOn(`anorm-core`)
 
@@ -407,55 +422,57 @@ val playVer = Def.setting[String] {
 }
 
 lazy val `anorm-postgres` = (project in file("postgres"))
-  .settings(common)
   .settings(
-    mimaPreviousArtifacts := Set.empty,
-    scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") {
-        Seq.empty
-      } else {
+    Seq(
+      mimaPreviousArtifacts := Set.empty,
+      scalacOptions ++= {
+        if (scalaBinaryVersion.value == "3") {
+          Seq.empty
+        } else {
+          Seq(
+            "-P:silencer:globalFilters=.*package object inheritance is deprecated.*",
+          )
+        }
+      },
+      libraryDependencies ++= {
+        val v = scalaBinaryVersion.value
+
+        val playJsonVer = {
+          if (v == "2.13" || v == "3") "2.10.4"
+          else "2.6.7"
+        }
+
         Seq(
-          "-P:silencer:globalFilters=.*package object inheritance is deprecated.*",
-        )
+          "org.postgresql"          % "postgresql" % pgVer,
+          "com.typesafe.play"      %% "play-json"  % playJsonVer,
+          "org.scala-lang.modules" %% "scala-xml"  % xmlVer.value % Test
+        ) ++ specs2Test :+ acolyte
       }
-    },
-    libraryDependencies ++= {
-      val v = scalaBinaryVersion.value
-
-      val playJsonVer = {
-        if (v == "2.13" || v == "3") "2.10.4"
-        else "2.6.7"
-      }
-
-      Seq(
-        "org.postgresql"          % "postgresql" % pgVer,
-        "com.typesafe.play"      %% "play-json"  % playJsonVer,
-        "org.scala-lang.modules" %% "scala-xml"  % xmlVer.value % Test
-      ) ++ specs2Test :+ acolyte
-    }
+    ) ++ licensing
   )
   .dependsOn(`anorm-core`)
 
 lazy val `anorm-enumeratum` = (project in file("enumeratum"))
-  .settings(common)
   .settings(
-    sourceDirectory := {
-      if (scalaBinaryVersion.value == "3") new java.io.File("/no/sources")
-      else sourceDirectory.value
-    },
-    publish / skip        := { scalaBinaryVersion.value == "3" },
-    mimaPreviousArtifacts := Set.empty,
-    libraryDependencies ++= {
-      if (scalaBinaryVersion.value != "3") {
-        Seq(
-          "org.scala-lang.modules" %% "scala-xml"  % xmlVer.value % Test,
-          "com.beachape"           %% "enumeratum" % "1.7.2",
-          acolyte
-        ) ++ specs2Test
-      } else {
-        Seq.empty
+    Seq(
+      sourceDirectory := {
+        if (scalaBinaryVersion.value == "3") new java.io.File("/no/sources")
+        else sourceDirectory.value
+      },
+      publish / skip        := { scalaBinaryVersion.value == "3" },
+      mimaPreviousArtifacts := Set.empty,
+      libraryDependencies ++= {
+        if (scalaBinaryVersion.value != "3") {
+          Seq(
+            "org.scala-lang.modules" %% "scala-xml"  % xmlVer.value % Test,
+            "com.beachape"           %% "enumeratum" % "1.7.2",
+            acolyte
+          ) ++ specs2Test
+        } else {
+          Seq.empty
+        }
       }
-    }
+    ) ++ licensing
   )
   .dependsOn(`anorm-core`)
 
@@ -472,37 +489,39 @@ lazy val `anorm-parent` = (project in file("."))
     `anorm-postgres`,
     `anorm-enumeratum`
   )
-  .settings(common)
   .settings(
-    mimaPreviousArtifacts := Set.empty,
-    (Compile / headerSources) ++=
-      ((baseDirectory.value ** ("*.properties" || "*.md" || "*.sbt"))
-        --- (baseDirectory.value ** "target" ** "*")
-        --- (baseDirectory.value / ".github" ** "*")
-        --- (baseDirectory.value / "docs" ** "*")).get ++
-        (baseDirectory.value / "project" ** "*.scala" --- (baseDirectory.value ** "target" ** "*")).get
+    Seq(
+      mimaPreviousArtifacts := Set.empty,
+      Compile / headerSources ++=
+        ((baseDirectory.value ** ("*.properties" || "*.md" || "*.sbt"))
+          --- (baseDirectory.value ** "target" ** "*")
+          --- (baseDirectory.value / ".github" ** "*")
+          --- (baseDirectory.value / "docs" ** "*")).get ++
+          (baseDirectory.value / "project" ** "*.scala" --- (baseDirectory.value ** "target" ** "*")).get
+    ) ++ licensing
   )
 
 lazy val docs = project
   .in(file("docs"))
   .enablePlugins(Playdoc)
   .configs(Docs)
-  .settings(common)
   .settings(
-    name := "anorm-docs",
-    (Test / unmanagedSourceDirectories) ++= {
-      val manualDir = baseDirectory.value / "manual" / "working"
+    Seq(
+      name := "anorm-docs",
+      (Test / unmanagedSourceDirectories) ++= {
+        val manualDir = baseDirectory.value / "manual" / "working"
 
-      (manualDir / "javaGuide" ** "code").get ++ (manualDir / "scalaGuide" ** "code").get
-    },
-    libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-jdbc"   % playVer.value % Test,
-      "com.typesafe.play" %% "play-specs2" % playVer.value % Test,
-      "com.h2database"     % "h2"          % "1.4.199"
-    ),
-    (Compile / headerSources) ++=
-      ((baseDirectory.value ** ("*.md" || "*.scala" || "*.xml"))
-        --- (baseDirectory.value ** "target" ** "*")).get
+        (manualDir / "javaGuide" ** "code").get ++ (manualDir / "scalaGuide" ** "code").get
+      },
+      libraryDependencies ++= Seq(
+        "com.typesafe.play" %% "play-jdbc"   % playVer.value % Test,
+        "com.typesafe.play" %% "play-specs2" % playVer.value % Test,
+        "com.h2database"     % "h2"          % "1.4.199"
+      ),
+      (Compile / headerSources) ++=
+        ((baseDirectory.value ** ("*.md" || "*.scala" || "*.xml"))
+          --- (baseDirectory.value ** "target" ** "*")).get
+    ) ++ licensing
   )
   .dependsOn(`anorm-core`)
 

--- a/core/src/main/scala-2/anorm/Macro.scala
+++ b/core/src/main/scala-2/anorm/Macro.scala
@@ -98,9 +98,7 @@ object Macro extends MacroOptions {
   }
 
   def indexedParserImpl[T: c.WeakTypeTag](c: whitebox.Context): c.Expr[RowParser[T]] = {
-    import c.universe._
-
-    @silent def p = reify(0)
+    @silent def p = c.universe.reify(0)
 
     offsetParserImpl[T](c)(p)
   }

--- a/core/src/main/scala-2/anorm/macros/ImplicitResolver.scala
+++ b/core/src/main/scala-2/anorm/macros/ImplicitResolver.scala
@@ -61,8 +61,8 @@ object ImplicitResolver {
           replacement: Type,
           altered: Boolean
       ): (Type, Boolean) = in match {
-        case tpe :: ts =>
-          boundTypes.getOrElse(tpe.typeSymbol.fullName, tpe) match {
+        case itpe :: ts =>
+          boundTypes.getOrElse(itpe.typeSymbol.fullName, itpe) match {
             case t if filter(t) =>
               refactor(ts, base, replacement :: out, tail, filter, replacement, true)
 
@@ -73,13 +73,13 @@ object ImplicitResolver {
           }
 
         case _ => {
-          val tpe = appliedType(base, out.reverse)
+          val itpe = appliedType(base, out.reverse)
 
           tail match {
             case (x, y, more) :: ts =>
-              refactor(x, y, tpe :: more, ts, filter, replacement, altered)
+              refactor(x, y, itpe :: more, ts, filter, replacement, altered)
 
-            case _ => tpe -> altered
+            case _ => itpe -> altered
           }
         }
       }

--- a/core/src/main/scala-2/anorm/package.scala
+++ b/core/src/main/scala-2/anorm/package.scala
@@ -32,7 +32,8 @@ package object anorm extends anorm.TopLevelDefinitions {
    */
   implicit class SqlStringInterpolation(val sc: StringContext) extends AnyVal {
     def SQL(args: ParameterValue*) = {
-      val (ts, ps) = TokenizedStatement.stringInterpolation(sc.parts, args)
+      val (ts, ps) = TokenizedStatement.stringInterpolation(sc.parts.toSeq, args)
+
       SimpleSql(SqlQuery.prepare(ts, ts.names), ps, RowParser(Success(_)))
     }
   }

--- a/core/src/main/scala-3/anorm/Macro.scala
+++ b/core/src/main/scala-3/anorm/Macro.scala
@@ -244,7 +244,7 @@ object Macro extends MacroOptions with macros.ValueColumn with macros.ValueToSta
    * @param projection $projectionParam
    * @tparam T $caseTParam
    */
-  inline def toParameters[T](inline separator: String, projection: ParameterProjection*): ToParameterList[T] = ${
+  inline def toParameters[T](inline separator: String, inline projection: ParameterProjection*): ToParameterList[T] = ${
     parametersWithSeparator[T]('separator, 'projection)
   }
 
@@ -484,7 +484,7 @@ object Macro extends MacroOptions with macros.ValueColumn with macros.ValueToSta
   private def parametersWithSeparator[T](
       separator: Expr[String],
       projection: Expr[Seq[ParameterProjection]]
-  )(using q: Quotes, tpe: Type[T]): Expr[ToParameterList[T]] = {
+  )(using q: Quotes, tpe: Type[T], proj: Type[ParameterProjection]): Expr[ToParameterList[T]] = {
     import q.reflect.*
 
     '{

--- a/core/src/main/scala-3/anorm/macros/ImplicitResolver.scala
+++ b/core/src/main/scala-3/anorm/macros/ImplicitResolver.scala
@@ -144,7 +144,7 @@ private[macros] trait ImplicitResolver[A, Q <: Quotes] {
    * @param forwardExpr the `Expr` that forward to the materialized instance itself
    */
   private class ImplicitTransformer[T](forwardExpr: Expr[T]) extends TreeMap {
-    private val denorm = denormalized _
+    private val denorm = denormalized
 
     @SuppressWarnings(Array("AsInstanceOf"))
     override def transformTree(tree: Tree)(owner: Symbol): Tree = tree match {

--- a/core/src/main/scala-3/anorm/macros/RowParserImpl.scala
+++ b/core/src/main/scala-3/anorm/macros/RowParserImpl.scala
@@ -6,8 +6,8 @@ package anorm.macros
 
 import scala.quoted.{ Expr, Quotes, Type }
 
-import anorm.{ Column, Row, RowParser, SqlResult, ~ }
-import anorm.Macro.{ RowParserGenerator, debugEnabled }
+import anorm.{ ~, Column, Row, RowParser, SqlResult }
+import anorm.Macro.{ debugEnabled, RowParserGenerator }
 
 private[anorm] object RowParserImpl {
   def apply[A](

--- a/core/src/main/scala-3/anorm/macros/SealedRowParserImpl.scala
+++ b/core/src/main/scala-3/anorm/macros/SealedRowParserImpl.scala
@@ -6,8 +6,8 @@ package anorm.macros
 
 import scala.quoted.{ Expr, Quotes, Type }
 
-import anorm.Macro.{ debugEnabled, Discriminate, DiscriminatorNaming }
 import anorm.{ Error, RowParser, SqlMappingError, SqlParser }
+import anorm.Macro.{ debugEnabled, Discriminate, DiscriminatorNaming }
 
 private[anorm] object SealedRowParserImpl {
   def apply[A](

--- a/core/src/main/scala-3/anorm/macros/ToParameterListImpl.scala
+++ b/core/src/main/scala-3/anorm/macros/ToParameterListImpl.scala
@@ -6,7 +6,8 @@ package anorm.macros
 
 import scala.quoted.{ Expr, Quotes, Type }
 
-import anorm.{ Compat, Macro, ToParameterList, ToParameterValue, ToSql, ToStatement, NamedParameter }
+import anorm.{ Compat, Macro, NamedParameter, ToParameterList, ToParameterValue, ToSql, ToStatement }
+
 import Macro.{ debugEnabled, ParameterProjection }
 
 private[anorm] object ToParameterListImpl {

--- a/core/src/main/scala/anorm/Anorm.scala
+++ b/core/src/main/scala/anorm/Anorm.scala
@@ -209,9 +209,6 @@ private[anorm] trait Sql extends WithResult {
       generatedKeysParser: ResultSetParser[A],
       as: ColumnAliaser
   )(implicit connection: Connection): Try[A] = {
-    @com.github.ghik.silencer.silent
-    implicit def cls: ClassTag[ResultSet] = resultSetClassTag
-
     Sql.asTry(
       generatedKeysParser,
       prep(connection).flatMap { stmt =>

--- a/docs/manual/working/scalaGuide/main/sql/code/MacroToParameters.scala
+++ b/docs/manual/working/scalaGuide/main/sql/code/MacroToParameters.scala
@@ -5,6 +5,7 @@
 package scalaGuide.sql.anorm
 
 object MacroToParameters1 {
+  import anorm._
   // #caseClassToParameters1
   import anorm.{ Macro, SQL, ToParameterList }
   import anorm.NamedParameter

--- a/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
+++ b/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
@@ -13,12 +13,16 @@ import play.api.test.Helpers._
 class ScalaAnorm extends org.specs2.mutable.Specification {
   "Code samples".title
 
-  def createApp(additionalConfiguration: Map[String, _]): Application = {
+  def createApp(additionalConfiguration: Map[String, _]): Application =
     new GuiceApplicationBuilder().configure(additionalConfiguration).build()
-  }
 
   "Anorm" should {
-    "be usable in play" in new WithApplication(createApp(additionalConfiguration = inMemoryDatabase())) {
+    trait Scala211Compat {
+      def running(): Unit = ()
+    }
+
+    "be usable in play" in new WithApplication(createApp(additionalConfiguration = inMemoryDatabase()))
+      with Scala211Compat {
       override def running() = {
         val database = app.injector.instanceOf[Database]
         // #playdb
@@ -28,8 +32,9 @@ class ScalaAnorm extends org.specs2.mutable.Specification {
           val _: Boolean = SQL("Select 1").execute()
         }
         // #playdb
-        ok
       }
+
+      ok
     }
   }
 }

--- a/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
+++ b/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
@@ -19,15 +19,17 @@ class ScalaAnorm extends org.specs2.mutable.Specification {
 
   "Anorm" should {
     "be usable in play" in new WithApplication(createApp(additionalConfiguration = inMemoryDatabase())) {
-      val database = app.injector.instanceOf[Database]
-      // #playdb
-      import anorm._
+      override def running() = {
+        val database = app.injector.instanceOf[Database]
+        // #playdb
+        import anorm._
 
-      database.withConnection { implicit c =>
-        val _: Boolean = SQL("Select 1").execute()
+        database.withConnection { implicit c =>
+          val _: Boolean = SQL("Select 1").execute()
+        }
+        // #playdb
+        ok
       }
-      // #playdb
-      ok
     }
   }
 }

--- a/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
+++ b/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
@@ -11,7 +11,7 @@ import play.api.test._
 import play.api.test.Helpers._
 
 class ScalaAnorm extends org.specs2.mutable.Specification {
-  "Code samples" title
+  "Code samples".title
 
   def createApp(additionalConfiguration: Map[String, _]): Application = {
     new GuiceApplicationBuilder().configure(additionalConfiguration).build()

--- a/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
+++ b/docs/manual/working/scalaGuide/main/sql/code/ScalaAnorm.scala
@@ -42,8 +42,8 @@ object MacroParsers {
 
   // First, RowParser instances for all the subtypes must be provided,
   // either by macros or by custom parsers
-  implicit val barParser = Macro.namedParser[Bar]
-  implicit val loremParser = RowParser[Lorem.type] { _ /*anyRowDiscriminatedAsLorem*/ =>
+  implicit val barParser: RowParser[Bar] = Macro.namedParser[Bar]
+  implicit val loremParser: RowParser[Lorem.type] = RowParser[Lorem.type] { _ /*anyRowDiscriminatedAsLorem*/ =>
     Success(Lorem)
   }
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -22,8 +22,8 @@ object Common extends AutoPlugin {
   override def projectSettings = Seq(
     organization        := "org.playframework.anorm",
     sonatypeProfileName := "org.playframework",
-    scalaVersion        := "2.12.18",
-    crossScalaVersions  := Seq("2.11.12", scalaVersion.value, "2.13.12", "3.3.1"),
+    scalaVersion        := "2.12.19",
+    crossScalaVersions  := Seq("2.11.12", scalaVersion.value, "2.13.13", "3.3.3"),
     (Compile / unmanagedSourceDirectories) ++= {
       val sv = scalaVersion.value
 
@@ -32,7 +32,7 @@ object Common extends AutoPlugin {
     (Test / unmanagedSourceDirectories) ++= scalaUnmanaged(scalaVersion.value, (Test / sourceDirectory).value),
     ThisBuild / libraryDependencies ++= {
       if (scalaBinaryVersion.value != "3") {
-        val silencerVersion = "1.7.14"
+        val silencerVersion = "1.7.16"
 
         Seq(
           compilerPlugin(

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -6,13 +6,11 @@ import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
-import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern.commentBetween
-import de.heikoseeberger.sbtheader.{ CommentStyle, FileType, HeaderPlugin, LineCommentCreator }
+
 import xerial.sbt.Sonatype.autoImport._
 
 object Common extends AutoPlugin {
   import com.typesafe.tools.mima.core._
-  import HeaderPlugin.autoImport._
 
   override def trigger  = allRequirements
   override def requires = JvmPlugin
@@ -23,16 +21,16 @@ object Common extends AutoPlugin {
     organization        := "org.playframework.anorm",
     sonatypeProfileName := "org.playframework",
     scalaVersion        := "2.12.19",
-    crossScalaVersions  := Seq("2.11.12", scalaVersion.value, "2.13.13", "3.3.3"),
-    (Compile / unmanagedSourceDirectories) ++= {
+    crossScalaVersions  := Seq("2.11.12", scalaVersion.value, "2.13.14", "3.4.2"),
+    Compile / unmanagedSourceDirectories ++= {
       val sv = scalaVersion.value
 
       scalaUnmanaged(sv, (Compile / sourceDirectory).value)
     },
-    (Test / unmanagedSourceDirectories) ++= scalaUnmanaged(scalaVersion.value, (Test / sourceDirectory).value),
+    Test / unmanagedSourceDirectories ++= scalaUnmanaged(scalaVersion.value, (Test / sourceDirectory).value),
     ThisBuild / libraryDependencies ++= {
       if (scalaBinaryVersion.value != "3") {
-        val silencerVersion = "1.7.16"
+        val silencerVersion = "1.7.17"
 
         Seq(
           compilerPlugin(
@@ -46,17 +44,28 @@ object Common extends AutoPlugin {
     },
     scalacOptions ++= Seq("-Xfatal-warnings"),
     scalacOptions ++= {
-      if (scalaBinaryVersion.value != "3") {
-        Seq("-target:jvm-1.8", "-Xlint", "-g:vars")
+      val v = scalaBinaryVersion.value
+
+      if (v == "2.13") {
+        Seq("-release", "8") :+ "-Xlint"
+      } else if (v == "3") {
+        Seq("-release", "8")
       } else {
-        Seq.empty
+        Seq("-target:jvm-1.8", "-g:vars") :+ "-Xlint"
       }
     },
     scalacOptions ++= {
       val v = scalaBinaryVersion.value
 
       if (v == "3") {
-        Seq("-explaintypes", "-Werror")
+        Seq(
+          "-explaintypes",
+          "-Werror",
+          "-Wconf:msg=.*with\\ as\\ a\\ type\\ operator.*:s",
+          "-Wconf:msg=.*deprecated.*uninitialized.*:s",
+          "-Wconf:msg=.*vararg\\ splices.*:s",
+          "-Wconf:cat=deprecation&msg=.*(reflectiveSelectableFromLangReflectiveCalls|DeprecatedSqlParser|missing .*ToSql|deprecatedName).*:s"
+        )
       } else if (v == "2.12") {
         Seq(
           "-Xmax-classfile-name",
@@ -72,6 +81,7 @@ object Common extends AutoPlugin {
       } else if (v == "2.11") {
         Seq("-Xmax-classfile-name", "128", "-Yopt:_", "-Ydead-code", "-Yclosure-elim", "-Yconst-opt")
       } else {
+        // 2.13
         Seq(
           "-explaintypes",
           "-Werror",
@@ -80,7 +90,9 @@ object Common extends AutoPlugin {
           "-Wdead-code",
           "-Wvalue-discard",
           "-Wextra-implicit",
-          "-Wmacros:after"
+          "-Wmacros:after",
+          "-Wconf:msg=.*type\\ Seq\\ in\\ package\\ scala\\ has\\ changed\\ semantics.*:s",
+          "-Wconf:cat=deprecation&msg=.*(reflectiveSelectableFromLangReflectiveCalls|DeprecatedSqlParser|missing .*ToSql|deprecatedName).*:s"
         )
       }
     },
@@ -97,18 +109,7 @@ object Common extends AutoPlugin {
     Test / scalacOptions ~= (_.filterNot(_ == "-Werror")),
     scalacOptions ~= (_.filterNot(_ == "-Xfatal-warnings")),
     Test / fork           := true,
-    mimaPreviousArtifacts := previousVersion.map(organization.value %% moduleName.value % _).toSet,
-    headerLicense := Some(
-      HeaderLicense.Custom(
-        "Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>"
-      )
-    ),
-    headerMappings ++= Map(
-      FileType("sbt")        -> HeaderCommentStyle.cppStyleLineComment,
-      FileType("properties") -> HeaderCommentStyle.hashLineComment,
-      FileType.xml           -> HeaderCommentStyle.xmlStyleBlockComment,
-      FileType("md") -> CommentStyle(new LineCommentCreator("<!---", "-->"), commentBetween("<!---", "*", "-->"))
-    ),
+    mimaPreviousArtifacts := previousVersion.map(organization.value %% moduleName.value % _).toSet
   ) ++ Publish.settings
 
   @inline def missMeth(n: String) =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,3 +1,3 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
-sbt.version=1.9.9
+sbt.version=1.10.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,3 +1,3 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
-sbt.version=1.9.6
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.3")
 
 addSbtPlugin("cchantep" % "sbt-scaladoc-compiler" % "0.2")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 


### PR DESCRIPTION
This way the "Dependency Graph" workflow should become green as soon as we release a Play 2.9 version / milestone with Scala 3 artifacts: https://github.com/playframework/anorm/actions/workflows/dependency-graph.yml