### PR TITLE
Add PekkoStream

### DIFF
--- a/akka/src/test/scala-2.12+/StreamTestKit.scala
+++ b/akka/src/test/scala-2.12+/StreamTestKit.scala
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package anorm
+
+import akka.stream.Materializer
+import akka.stream.testkit.scaladsl.{ StreamTestKit => AkkaTestKit }
+
+private[anorm] object StreamTestKit {
+  def assertAllStagesStopped[T](f: => T)(implicit mat: Materializer): T =
+    AkkaTestKit.assertAllStagesStopped(f)
+}

--- a/akka/src/test/scala-2.12-/StreamTestKit.scala
+++ b/akka/src/test/scala-2.12-/StreamTestKit.scala
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package anorm
+
+/* No valid testkit for 2.11 */
+private[anorm] object StreamTestKit {
+  def assertAllStagesStopped[T](f: => T): T = f
+}

--- a/akka/src/test/scala/anorm/AkkaStreamSpec.scala
+++ b/akka/src/test/scala/anorm/AkkaStreamSpec.scala
@@ -15,7 +15,6 @@ import akka.actor.ActorSystem
 
 import akka.stream.Materializer
 import akka.stream.scaladsl.{ Keep, Sink, Source }
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 
 import acolyte.jdbc.AcolyteDSL.withQueryResult
 import acolyte.jdbc.Implicits._
@@ -32,6 +31,8 @@ final class AkkaStreamSpec(implicit ee: ExecutionEnv) extends org.specs2.mutable
 
   implicit def materializer: Materializer =
     akka.stream.ActorMaterializer.create(system)
+
+  import StreamTestKit.assertAllStagesStopped
 
   "Akka Stream" should {
     "expose the query result as source" in assertAllStagesStopped {

--- a/build.sbt
+++ b/build.sbt
@@ -328,7 +328,8 @@ lazy val `anorm-pekko` = (project in file("pekko"))
 
       }
     },
-    crossScalaVersions -= "2.11.12"
+    crossScalaVersions -= "2.11.12",
+    mimaFailOnNoPrevious := false
   )
   .dependsOn(`anorm-core`)
 

--- a/build.sbt
+++ b/build.sbt
@@ -328,7 +328,7 @@ lazy val `anorm-pekko` = (project in file("pekko"))
 
       }
     },
-    crossScalaVersions -= "2.11.12",
+    crossScalaVersions --= Seq("2.11.12", "2.12.18"),
     mimaFailOnNoPrevious := false
   )
   .dependsOn(`anorm-core`)

--- a/pekko/src/main/scala/anorm/PekkoStream.scala
+++ b/pekko/src/main/scala/anorm/PekkoStream.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package anorm
+
+import java.sql.Connection
+
+import scala.util.control.NonFatal
+
+import scala.concurrent.{ Future, Promise }
+
+import org.apache.pekko.stream.scaladsl.Source
+
+/**
+ * Anorm companion for the Pekko Streams.
+ *
+ * @define materialization It materializes a [[scala.concurrent.Future]] of [[scala.Int]] containing the number of rows read from the source upon completion, and a possible exception if row parsing failed.
+ * @define sqlParam the SQL query
+ * @define connectionParam the JDBC connection, which must not be closed until the source is materialized.
+ * @define columnAliaserParam the column aliaser
+ */
+object PekkoStream {
+
+  /**
+   * Returns the rows parsed from the `sql` query as a reactive source.
+   *
+   * $materialization
+   *
+   * @tparam T the type of the result elements
+   * @param sql $sqlParam
+   * @param parser the result (row) parser
+   * @param as $columnAliaserParam
+   * @param connection $connectionParam
+   *
+   * {{{
+   * import java.sql.Connection
+   *
+   * import scala.concurrent.Future
+   *
+   * import org.apache.pekko.stream.scaladsl.Source
+   *
+   * import anorm._
+   *
+   * def resultSource(implicit con: Connection): Source[String, Future[Int]] = PekkoStream.source(SQL"SELECT * FROM Test", SqlParser.scalar[String], ColumnAliaser.empty)
+   * }}}
+   */
+  @SuppressWarnings(Array("UnusedMethodParameter"))
+  def source[T](sql: => Sql, parser: RowParser[T], as: ColumnAliaser)(implicit
+      con: Connection
+  ): Source[T, Future[Int]] = Source.fromGraph(new ResultSource[T](con, sql, as, parser))
+
+  /**
+   * Returns the rows parsed from the `sql` query as a reactive source.
+   *
+   * $materialization
+   *
+   * @tparam T the type of the result elements
+   * @param sql $sqlParam
+   * @param parser the result (row) parser
+   * @param connection $connectionParam
+   */
+  @SuppressWarnings(Array("UnusedMethodParameter"))
+  def source[T](sql: => Sql, parser: RowParser[T])(implicit con: Connection): Source[T, Future[Int]] =
+    source[T](sql, parser, ColumnAliaser.empty)
+
+  /**
+   * Returns the result rows from the `sql` query as an enumerator.
+   * This is equivalent to `source[Row](sql, RowParser.successful, as)`.
+   *
+   * $materialization
+   *
+   * @param sql $sqlParam
+   * @param as $columnAliaserParam
+   * @param connection $connectionParam
+   */
+  def source(sql: => Sql, as: ColumnAliaser)(implicit connection: Connection): Source[Row, Future[Int]] =
+    source(sql, RowParser.successful, as)
+
+  /**
+   * Returns the result rows from the `sql` query as an enumerator.
+   * This is equivalent to
+   * `source[Row](sql, RowParser.successful, ColumnAliaser.empty)`.
+   *
+   * $materialization
+   *
+   * @param sql $sqlParam
+   * @param connection $connectionParam
+   */
+  def source(sql: => Sql)(implicit connnection: Connection): Source[Row, Future[Int]] =
+    source(sql, RowParser.successful, ColumnAliaser.empty)
+
+  // Internal stages
+
+  import org.apache.pekko.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, OutHandler }
+  import org.apache.pekko.stream.{ Attributes, Outlet, SourceShape }
+
+  import java.sql.ResultSet
+  import scala.util.{ Failure, Success }
+
+  private[anorm] class ResultSource[T](connection: Connection, sql: Sql, as: ColumnAliaser, parser: RowParser[T])
+      extends GraphStageWithMaterializedValue[SourceShape[T], Future[Int]] {
+
+    private[anorm] var resultSet: ResultSet = _
+
+    override val toString     = "AnormQueryResult"
+    val out: Outlet[T]        = Outlet(s"${toString}.out")
+    val shape: SourceShape[T] = SourceShape(out)
+
+    override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Int]) = {
+      val result = Promise[Int]()
+
+      val logic = new GraphStageLogic(shape) with OutHandler {
+        private var cursor: Option[Cursor] = None
+        private var counter: Int           = 0
+
+        private def failWith(cause: Throwable): Unit = {
+          result.failure(cause)
+          fail(out, cause)
+          ()
+        }
+
+        override def preStart(): Unit = {
+          try {
+            resultSet = sql.unsafeResultSet(connection)
+            nextCursor()
+          } catch {
+            case NonFatal(cause) => failWith(cause)
+          }
+        }
+
+        override def postStop() = release()
+
+        private def release(): Unit = {
+          val stmt: Option[java.sql.Statement] = {
+            if (resultSet != null && !resultSet.isClosed) {
+              val s = resultSet.getStatement
+              resultSet.close()
+              Option(s)
+            } else None
+          }
+
+          stmt.foreach { s =>
+            if (!s.isClosed) s.close()
+          }
+        }
+
+        private def nextCursor(): Unit = {
+          cursor = Sql.unsafeCursor(resultSet, sql.resultSetOnFirstRow, as)
+        }
+
+        def onPull(): Unit = cursor match {
+          case Some(c) =>
+            c.row.as(parser) match {
+              case Success(parsed) => {
+                counter += 1
+                push(out, parsed)
+                nextCursor()
+              }
+
+              case Failure(cause) =>
+                failWith(cause)
+            }
+
+          case _ => {
+            result.success(counter)
+            complete(out)
+          }
+        }
+
+        override def onDownstreamFinish() = {
+          result.tryFailure(new InterruptedException("Downstream finished"))
+          release()
+          super.onDownstreamFinish()
+        }
+
+        setHandler(out, this)
+      }
+
+      logic -> result.future
+    }
+  }
+
+}

--- a/pekko/src/test/resources/reference.conf
+++ b/pekko/src/test/resources/reference.conf
@@ -1,0 +1,3 @@
+pekko {
+  loglevel = "OFF"
+}

--- a/pekko/src/test/scala-2.13+/PekkoCompat.scala
+++ b/pekko/src/test/scala-2.13+/PekkoCompat.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package anorm
+
+private[anorm] object PekkoCompat {
+  type Seq[T] = _root_.scala.collection.immutable.Seq[T]
+}

--- a/pekko/src/test/scala-2.13-/PekkoCompat.scala
+++ b/pekko/src/test/scala-2.13-/PekkoCompat.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package anorm
+
+private[anorm] object PekkoCompat {
+  type Seq[T] = _root_.scala.collection.Seq[T]
+}

--- a/pekko/src/test/scala/anorm/PekkoStreamSpec.scala
+++ b/pekko/src/test/scala/anorm/PekkoStreamSpec.scala
@@ -11,12 +11,6 @@ import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import akka.actor.ActorSystem
-
-import akka.stream.Materializer
-import akka.stream.scaladsl.{ Keep, Sink, Source }
-import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
-
 import acolyte.jdbc.AcolyteDSL.withQueryResult
 import acolyte.jdbc.Implicits._
 import acolyte.jdbc.QueryResult
@@ -24,19 +18,24 @@ import acolyte.jdbc.RowLists.stringList
 
 import org.specs2.concurrent.ExecutionEnv
 
-final class AkkaStreamSpec(implicit ee: ExecutionEnv) extends org.specs2.mutable.Specification {
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{ Keep, Sink, Source }
+import org.apache.pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 
-  "Akka Stream".title
+final class PekkoStreamSpec(implicit ee: ExecutionEnv) extends org.specs2.mutable.Specification {
+
+  "Pekko Stream".title
 
   implicit lazy val system: ActorSystem = ActorSystem("anorm-tests")
 
   implicit def materializer: Materializer =
-    akka.stream.ActorMaterializer.create(system)
+    org.apache.pekko.stream.ActorMaterializer.create(system)
 
-  "Akka Stream" should {
+  "Pekko Stream" should {
     "expose the query result as source" in assertAllStagesStopped {
       withQueryResult(stringList :+ "A" :+ "B" :+ "C") { implicit con =>
-        AkkaStream
+        PekkoStream
           .source(SQL"SELECT * FROM Test", SqlParser.scalar[String])
           .runWith(Sink.seq[String]) must beTypedEqualTo(
           Seq("A", "B", "C")
@@ -46,7 +45,7 @@ final class AkkaStreamSpec(implicit ee: ExecutionEnv) extends org.specs2.mutable
 
     "be done if the stream run through" in {
       withQueryResult(stringList :+ "A" :+ "B" :+ "C") { implicit con =>
-        AkkaStream
+        PekkoStream
           .source(SQL"SELECT * FROM Test", SqlParser.scalar[String])
           .toMat(Sink.ignore)(Keep.left)
           .run() must beTypedEqualTo(3).await(0, 3.seconds)
@@ -57,14 +56,14 @@ final class AkkaStreamSpec(implicit ee: ExecutionEnv) extends org.specs2.mutable
       val list = stringList :+ "A" :+ "B" :+ "C"
 
       withQueryResult(list.withCycling(true)) { implicit con =>
-        val killSwitch = akka.stream.KillSwitches.shared("cycling-switch")
+        val killSwitch = org.apache.pekko.stream.KillSwitches.shared("cycling-switch")
 
-        AkkaStream
+        PekkoStream
           .source(SQL"SELECT * FROM Test", SqlParser.scalar[String])
 
         val p = scala.concurrent.Promise[Int]()
 
-        val res = AkkaStream
+        val res = PekkoStream
           .source(SQL"SELECT * FROM Test", SqlParser.scalar[String])
           .mapMaterializedValue(p.completeWith)
           .via(killSwitch.flow)
@@ -126,7 +125,7 @@ final class AkkaStreamSpec(implicit ee: ExecutionEnv) extends org.specs2.mutable
             def unsafeStatement(
                 connection: Connection,
                 generatedColumn: String,
-                generatedColumns: AkkaCompat.Seq[String]
+                generatedColumns: PekkoCompat.Seq[String]
             ): PreparedStatement = ???
 
             def unsafeStatement(connection: Connection, getGeneratedKeys: Boolean): PreparedStatement =
@@ -155,5 +154,5 @@ final class AkkaStreamSpec(implicit ee: ExecutionEnv) extends org.specs2.mutable
   }
 
   def source[T](sql: Sql, parser: RowParser[T])(implicit connection: Connection) =
-    new AkkaStream.ResultSource[T](connection, sql, ColumnAliaser.empty, parser)
+    new PekkoStream.ResultSource[T](connection, sql, ColumnAliaser.empty, parser)
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -23,7 +23,7 @@ object Common extends AutoPlugin {
     organization        := "org.playframework.anorm",
     sonatypeProfileName := "org.playframework",
     scalaVersion        := "2.12.18",
-    crossScalaVersions  := Seq("2.11.12", scalaVersion.value, "2.13.11", "3.3.0"),
+    crossScalaVersions  := Seq("2.11.12", scalaVersion.value, "2.13.11", "3.3.1"),
     (Compile / unmanagedSourceDirectories) ++= {
       val sv = scalaVersion.value
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Adds `PekkoStream` to be used by Pekko users.

## Purpose

Many applications are now migrating to Pekko due to Akka's license change. Some of them might be using AkkaStream from anorm, this supports them with their migration. 

## Background Context

I do not think there is a better approach, we have to duplicate the code.

## References

https://github.com/playframework/anorm/issues/571