### PR TITLE
Fix revision numbers to ignore reformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,5 @@
 # Scala Steward: Reformat with scalafmt 3.5.8
-3707a3109e4491f9558fe95c649e66e124082a6a
+8596fb002f306de55f31ab8478c204ed98a60d9c
 
 # Scala Steward: Reformat with scalafmt 3.7.14
-a0bcfef8b2f360feb771cfe2c7f70ca01668337f
+50452b99e0921cc52c4547d2bd8be510d3356283


### PR DESCRIPTION
We should be more attention when merge by rebase/squash a scalafmt PRs.