### PR TITLE
Set Java version to publish explicitly

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,1 @@
+extends: .github

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,3 +13,5 @@ jobs:
     name: Publish / Artifacts
     uses: playframework/.github/.github/workflows/publish.yml@v3
     secrets: inherit
+    with:
+      java: 8


### PR DESCRIPTION
I think we should set Java version to publish explicitly until we don't decided finally about dropping Java 8 for Anorm (#488).

PS: I know about `-target:jvm-1.8` in `scalacOptions` but anyway.

As a bonus, I added a Mergify config 😄 