### PR TITLE
Version should support milestone and release candidates

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -3,7 +3,7 @@
 ThisBuild / dynverVTagPrefix := false
 
 (ThisBuild / version) := {
-  val Stable = """([0-9]+)\.([0-9]+)\.([0-9]+)""".r
+  val Stable = """([0-9]+)\.([0-9]+)\.([0-9]+)(-(?:M|RC)[0-9]+)?""".r
 
   (ThisBuild / dynverGitDescribeOutput).value match {
     case Some(descr) => {
@@ -11,8 +11,8 @@ ThisBuild / dynverVTagPrefix := false
         (ThisBuild / previousStableVersion).value match {
           case Some(previousVer) => {
             val current = (for {
-              Seq(maj, min, patch) <- Stable.unapplySeq(previousVer)
-              nextPatch            <- scala.util.Try(patch.toInt).map(_ + 1).toOption
+              Seq(maj, min, patch, milestone) <- Stable.unapplySeq(previousVer)
+              nextPatch                       <- scala.util.Try(patch.toInt).map(_ + 1).toOption
             } yield {
               val suffix = descr.commitSuffix.sha
               s"${maj}.${min}.${nextPatch}-${suffix}-SNAPSHOT"


### PR DESCRIPTION
I tagged `2.9.0-M1` but now sbt does not start anymore...

```
java.lang.RuntimeException: Fails to determine qualified snapshot version
        at scala.sys.package$.error(package.scala:30)
        at $9ba5b759634520e30e20$.$anonfun$$sbtdef$7(/home/mkurz/work/github-play-repos/anorm/version.sbt:23)
        at scala.Option.getOrElse(Option.scala:189)
        at $9ba5b759634520e30e20$.$anonfun$$sbtdef$1(/home/mkurz/work/github-play-repos/anorm/version.sbt:23)
        at scala.Function1.$anonfun$compose$1(Function1.scala:49)
        at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:229)
        at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:171)
        at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:88)
        at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:100)
        at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:95)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)

```