### PR TITLE
📦 ci(release-draft): temporarily remove name as it generates an error

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v7
         with:
-          name: "Anorm $RESOLVED_VERSION"
+          #name: "Anorm $RESOLVED_VERSION"
           config-name: .github:release-drafts/increasing-minor-version.yml # located in .github/ in the default branch of the .github repo
           commitish: ${{ github.ref_name }}
         env:


### PR DESCRIPTION
Error is: 'Warning: Failed to parse version from input Anorm $RESOLVED_VERSION. Defaulting to null.' (see https://github.com/playframework/anorm/actions/runs/24308200759/job/70973075626)
