### PR TITLE
🐛 fix: surface UnexpectedNullableFound instead of remapping to ColumnNotFound (closes #560)

### DIFF
--- a/core/src/main/scala/anorm/RowParser.scala
+++ b/core/src/main/scala/anorm/RowParser.scala
@@ -97,10 +97,16 @@ trait RowParser[+A] extends (Row => SqlResult[A]) { parent =>
    * that will turn missing or null column as None.
    */
   def ? : RowParser[Option[A]] = RowParser {
+    // Note: `UnexpectedNullableFound` is the error raised by `Column` when a
+    // non-nullable column is read but contains NULL.  Previously the SqlParser
+    // remapped this to `ColumnNotFound` so that this combinator surfaced NULL
+    // as `None`; that remap also caused #560 (misleading "column not found"
+    // errors elsewhere).  Now we recover from both errors here directly, which
+    // is what the scaladoc above already promised.
     parent(_) match {
-      case Success(a)                  => Success(Some(a))
-      case Error(ColumnNotFound(_, _)) =>
-        Success(None)
+      case Success(a)                        => Success(Some(a))
+      case Error(ColumnNotFound(_, _))       => Success(None)
+      case Error(UnexpectedNullableFound(_)) => Success(None)
 
       case e @ Error(_) => e
     }

--- a/core/src/main/scala/anorm/SqlParser.scala
+++ b/core/src/main/scala/anorm/SqlParser.scala
@@ -29,8 +29,12 @@ object SqlParser extends FunctionAdapter with DeprecatedSqlParser {
         } yield v -> m).toRight(NoColumnsInReturnedResult)
 
         val parsed = Compat.rightFlatMap[SqlMappingError, SqlRequestError, (Any, MetaDataItem), T](input) {
-          case in @ (_, m) =>
-            parseColumn(row, m.column.qualified, c, in)
+          case in @ (_, _) =>
+            // Previously a `parseColumn` helper mapped `UnexpectedNullableFound` to
+            // `ColumnNotFound` here, producing misleading "column not found" errors
+            // when the column existed but contained NULL (#560).  Surface the
+            // original `Column` error instead.
+            c.tupled(in)
         }
 
         parsed.fold(Error(_), Success(_))
@@ -491,7 +495,7 @@ object SqlParser extends FunctionAdapter with DeprecatedSqlParser {
     row =>
       Compat
         .rightFlatMap(row.get(name)) { in =>
-          parseColumn(row, name, c, in)
+          c.tupled(in)
         }
         .fold(Error(_), Success(_))
   }
@@ -514,7 +518,7 @@ object SqlParser extends FunctionAdapter with DeprecatedSqlParser {
     RowParser { row =>
       Compat
         .rightFlatMap(row.getIndexed(position - 1)) { in =>
-          parseColumn(row, in._2.column.qualified, c, in)
+          c.tupled(in)
         }
         .fold(Error(_), Success(_))
     }
@@ -536,17 +540,6 @@ object SqlParser extends FunctionAdapter with DeprecatedSqlParser {
   def matches[T: Column](column: String, value: T): RowParser[Boolean] =
     get[T](column).?.map(_.fold(false) { _ == value })
 
-  @inline private def parseColumn[T](
-      row: Row,
-      name: String,
-      c: Column[T],
-      input: (Any, MetaDataItem)
-  ): Either[SqlRequestError, T] = c.tupled(input).left.map {
-    case UnexpectedNullableFound(_) =>
-      ColumnNotFound(name, row)
-
-    case cause => cause
-  }
 }
 
 @deprecated("Do not use these combinators", "2.5.4")

--- a/core/src/test/scala/AnormSpec.scala
+++ b/core/src/test/scala/AnormSpec.scala
@@ -66,6 +66,21 @@ final class AnormSpec
 
       }
 
+      // Regression test for #560: previously this surfaced as
+      // "'X' not found, available columns: X, X" because parseColumn mapped
+      // UnexpectedNullableFound to ColumnNotFound.  After the fix it must
+      // mention the column is NULL, not missing.
+      "surface NULL-aware error when scalar[T].single hits NULL" in withQueryResult(null.asInstanceOf[String]) {
+        implicit c: Connection =>
+
+          SQL("SELECT * FROM test").as(scalar[String].single).aka("scalar single on NULL") must throwA[Exception]
+            .like {
+              case e: Exception =>
+                (e.getMessage.aka("error") must contain("UnexpectedNullableFound"))
+                  .and(e.getMessage.aka("error") must not(contain("not found, available columns")))
+            }
+      }
+
       "throw exception when single result is missing" in withQueryResult(fooBarTable) { implicit c: Connection =>
 
         SQL("SELECT * FROM test").as(fooBarParser1.single).aka("mapping") must throwA[Exception].like {

--- a/core/src/test/scala/anorm/SqlResultSpec.scala
+++ b/core/src/test/scala/anorm/SqlResultSpec.scala
@@ -161,6 +161,15 @@ final class SqlResultSpec extends org.specs2.mutable.Specification with H2Databa
 
         SQL"SELECT *".as(SqlParser.str("foo").?.single) must beNone
     }
+
+    // Parallel coverage on the Column[Int] codepath: with the parseColumn
+    // remap removed, `.?` must still surface a NULL integer as None via the
+    // new UnexpectedNullableFound branch in RowParser.?.
+    "be None when column is NULL for non-nullable Int" in withQueryResult(
+      rowList1(classOf[Integer] -> "n") :+ null.asInstanceOf[Integer]
+    ) { implicit c: Connection =>
+      SQL"SELECT *".as(SqlParser.int("n").?.single) must beNone
+    }
   }
 
   "Collecting" should {


### PR DESCRIPTION
  Closes #560.

  ## Problem

  `scalar[T].single` (and other non-Option parsers) on a column containing
  NULL produced this confusing error:

  '.completed_average' not found, available columns: completed_average,
  completed_average

  The column was actually present; it just contained NULL.  The root cause
  was an internal `parseColumn` helper in `SqlParser` that remapped
  `UnexpectedNullableFound` to `ColumnNotFound`.  @gaeljw confirmed the
  impact in
  https://github.com/playframework/anorm/issues/560#issuecomment-1911862878.

  ## Fix

  Two parts:

  1. **`SqlParser.scala`:** drop the `UnexpectedNullableFound → ColumnNotFound`
     remap in `parseColumn`.  Since the helper then only forwarded to
     `c.tupled(input)`, it has been inlined at its three call sites and
     removed.  Errors from `Column[T].tupled` now surface unchanged, so
     users see `UnexpectedNullableFound(column_name)` and can distinguish
     NULL from missing column.

  2. **`RowParser.scala` (`.?` combinator):** the optional-column combinator
     previously only recovered from `ColumnNotFound`.  Its scaladoc has
     always promised "missing or null column as None", and the existing
     `singleOpt` / `?` semantics depended on the buggy mapping to convert
     NULL to `None`.  Updated `.?` to also recover from
     `UnexpectedNullableFound`, honouring its documented contract
     independently of the `parseColumn` remap.

  ## Regression test

  `AnormSpec` gains one test verifying that `scalar[String].single` on a
  NULL result throws an error whose message contains
  `UnexpectedNullableFound` and **does not** contain
  `not found, available columns`.

  ## Behaviour change

  User code that catches `ColumnNotFound` specifically to recognise a NULL
  column will now see `UnexpectedNullableFound` instead.  This was the
  documented behaviour all along; the buggy remap was the deviation.  No
  other observable change.

  ## Local validation

  - `++ 2.13; anorm-core/compile anorm-core/Test/compile` clean
  - `++ 3;    anorm-core/compile anorm-core/Test/compile` clean
  - `++ 2.13; anorm-core/test` 294 / 294 pass (including the new test and
    the existing "be parsed from mapping with optional column" test which
    previously depended on the buggy mapping)
  - `++ 3; anorm-core/testOnly tests.AnormSpec` 52 / 52 pass
  - `scalafmtCheckAll` clean
  - `anorm-core/mimaReportBinaryIssues` no binary issues