### PR TITLE
🐛 fix: preserve nanosecond precision in Column[LocalDateTime] (#525)

### DIFF
--- a/core/src/main/scala/anorm/Column.scala
+++ b/core/src/main/scala/anorm/Column.scala
@@ -720,15 +720,19 @@ sealed trait JavaTimeColumn {
    * }}}
    */
   implicit val columnToLocalDateTime: Column[LocalDateTime] = {
-    def millisToLocalDateTime(ts: Long) =
-      LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), ZoneId.systemDefault)
+    def instantToLocalDateTime(instant: Instant) =
+      LocalDateTime.ofInstant(instant, ZoneId.systemDefault)
 
     nonNull { (value, meta) =>
       value match {
         case localDateTime: LocalDateTime => Right(localDateTime)
 
         case _ =>
-          temporalValueTo[LocalDateTime](millisToLocalDateTime, "Java8 LocalDateTime")(value, meta)
+          // Route through instantValueTo so Timestamp values keep nanosecond
+          // precision (via Timestamp#toInstant) instead of being truncated to
+          // milliseconds through Timestamp#getTime.  See #525, mirrors the
+          // fixes in #326 (Instant) and #409 (ZonedDateTime).
+          instantValueTo[LocalDateTime](instantToLocalDateTime, "Java8 LocalDateTime")(value, meta)
       }
     }
   }

--- a/core/src/main/scala/anorm/Column.scala
+++ b/core/src/main/scala/anorm/Column.scala
@@ -719,21 +719,15 @@ sealed trait JavaTimeColumn {
    *     as(SqlParser.scalar[LocalDateTime].single)
    * }}}
    */
-  implicit val columnToLocalDateTime: Column[LocalDateTime] = {
-    def instantToLocalDateTime(instant: Instant) =
-      LocalDateTime.ofInstant(instant, ZoneId.systemDefault)
+  implicit val columnToLocalDateTime: Column[LocalDateTime] = nonNull { (value, meta) =>
+    value match {
+      case localDateTime: LocalDateTime => Right(localDateTime)
 
-    nonNull { (value, meta) =>
-      value match {
-        case localDateTime: LocalDateTime => Right(localDateTime)
-
-        case _ =>
-          // Route through instantValueTo so Timestamp values keep nanosecond
-          // precision (via Timestamp#toInstant) instead of being truncated to
-          // milliseconds through Timestamp#getTime.  See #525, mirrors the
-          // fixes in #326 (Instant) and #409 (ZonedDateTime).
-          instantValueTo[LocalDateTime](instantToLocalDateTime, "Java8 LocalDateTime")(value, meta)
-      }
+      case _ =>
+        instantValueTo[LocalDateTime](LocalDateTime.ofInstant(_: Instant, ZoneId.systemDefault), "Java8 LocalDateTime")(
+          value,
+          meta
+        )
     }
   }
 

--- a/core/src/test/scala/anorm/JavaTimeSpec.scala
+++ b/core/src/test/scala/anorm/JavaTimeSpec.scala
@@ -86,6 +86,15 @@ final class JavaTimeColumnSpec extends Specification {
         SQL("SELECT ts").as(scalar[LocalDateTime].single).aka("parsed local date/time") must_=== date
     }
 
+    "be parsed from timestamp with nano precision" in {
+      val instantWithNanoPrecision = Instant.parse("2021-01-06T08:45:26.441477Z")
+      val expected                 = LocalDateTime.ofInstant(instantWithNanoPrecision, ZoneId.systemDefault)
+
+      withQueryResult(timestampList :+ Timestamp.from(instantWithNanoPrecision)) { implicit c: Connection =>
+        SQL("SELECT ts").as(scalar[LocalDateTime].single).aka("parsed local date/time") must_=== expected
+      }
+    }
+
     "be parsed from numeric time" in withQueryResult(longList :+ time) { implicit c: Connection =>
       SQL("SELECT time").as(scalar[LocalDateTime].single).aka("parsed local date/time") must_=== date
 


### PR DESCRIPTION
  Closes #525.

  ## Problem

  `scalar[LocalDateTime].single` on a `Timestamp` column with sub-millisecond
  precision truncates the nanoseconds (reproducer in
  https://github.com/oyvindberg/play-anorm-nano-precision):

  [info] - should insert a LocalDateTime instant WITH nano precision and return
  the inserted value *** FAILED ***
  [info]   2021-01-06T09:22:31.222 was not equal to 2021-01-06T09:22:31.222456

  Same bug class as #325 (`Instant`) and #408 (`ZonedDateTime`), fixed by #326
  and #409 respectively.

  ## Fix

  Route `columnToLocalDateTime`'s non-`LocalDateTime` cases through
  `instantValueTo` instead of `temporalValueTo`.  `instantValueTo` uses
  `Timestamp#toInstant` (which preserves nanos), while `temporalValueTo` went
  through `Timestamp#getTime → Instant.ofEpochMilli` (millis only).

  ## Regression test

  `JavaTimeColumnSpec` gains a "be parsed from timestamp with nano precision"
  case parallel to the existing `Instant` and `ZonedDateTime` versions.

  ## Local validation

  - `++ 2.13; anorm-core/compile anorm-core/Test/compile` clean
  - `++ 3; anorm-core/compile anorm-core/Test/compile` clean
  - `++ 2.13; anorm-core/test` 294 / 294 pass (including the new nano test)
  - `++ 3; anorm-core/testOnly anorm.JavaTimeColumnSpec` 27 / 27 pass
  - `scalafmtCheckAll` clean
  - `anorm-core/mimaReportBinaryIssues` no binary issues